### PR TITLE
Add -R option

### DIFF
--- a/man/cscout.1
+++ b/man/cscout.1
@@ -214,7 +214,7 @@ Specify the location of a file where web requests will be logged.
 .IP "\fB\-R\fP"
 Generate call graphs and exit.
 
-EXAMPLE: cscout -R cgraph.txt -R fgraph.txt?gtype=C.
+EXAMPLE cscout -R cgraph.txt -R fgraph.txt?gtype=C.
 
 .IP "\fB\-o\fP"
 Create obfuscated versions of all the writable files of the workspace.

--- a/man/cscout.1
+++ b/man/cscout.1
@@ -211,6 +211,8 @@ Specify \fIhelp\fP as the database dialect to obtain a list of
 supported database back-ends.
 .IP "\fB\-l\fP \fIlog file\fP"
 Specify the location of a file where web requests will be logged.
+.IP "\fB\-R\fP \fIlog file\fP"
+Generate call graphs and exit. Example: cscout -R cgraph.txt -R fgraph.txt\?gtype\=C. 
 .IP "\fB\-o\fP"
 Create obfuscated versions of all the writable files of the workspace.
 .PP

--- a/man/cscout.1
+++ b/man/cscout.1
@@ -211,8 +211,11 @@ Specify \fIhelp\fP as the database dialect to obtain a list of
 supported database back-ends.
 .IP "\fB\-l\fP \fIlog file\fP"
 Specify the location of a file where web requests will be logged.
-.IP "\fB\-R\fP \fIlog file\fP"
-Generate call graphs and exit. Example: cscout -R cgraph.txt -R fgraph.txt\?gtype\=C. 
+.IP "\fB\-R\fP"
+Generate call graphs and exit.
+
+EXAMPLE: cscout -R cgraph.txt -R fgraph.txt?gtype=C.
+
 .IP "\fB\-o\fP"
 Create obfuscated versions of all the writable files of the workspace.
 .PP

--- a/src/cscout.cpp
+++ b/src/cscout.cpp
@@ -3099,7 +3099,7 @@ usage(char *fname)
 #ifndef WIN32
 		"-b|"	// browse-only
 #endif
-		"-C|-c|-d D|-d H|-E|-o|"
+		"-C|-c|-R|-d D|-d H|-E|-o|"
 		"-r|-s db|-v] "
 		"[-l file] "
 
@@ -3116,6 +3116,7 @@ usage(char *fname)
 #endif
 		"\t-C\tCreate a ctags(1)-compatible tags file\n"
 		"\t-c\tProcess the file and exit\n"
+		"\t-R\tMake the specified REST API calls and exit\n"
 		"\t-d D\tOutput the #defines being processed on standard output\n"
 		"\t-d H\tOutput the included files being processed on standard output\n"
 		"\t-E\tPrint preprocessed results on standard output and exit\n"
@@ -3147,7 +3148,7 @@ main(int argc, char *argv[])
 
 	Debug::db_read();
 
-	while ((c = getopt(argc, argv, "3bCcd:rvEp:m:l:os:" PICO_QL_OPTIONS)) != EOF)
+	while ((c = getopt(argc, argv, "3bCcRd:rvEp:m:l:os:" PICO_QL_OPTIONS)) != EOF)
 		switch (c) {
 		case '3':
 			Fchar::enable_trigraphs();
@@ -3230,6 +3231,10 @@ main(int argc, char *argv[])
 			process_mode = pm_database;
 			db_engine = strdup(optarg);
 			break;
+		case 'R':
+			if (process_mode)
+				usage(argv[0]);
+			process_mode = pm_compile;
 		case '?':
 			usage(argv[0]);
 		}

--- a/src/cscout.cpp
+++ b/src/cscout.cpp
@@ -3161,9 +3161,10 @@ main(int argc, char *argv[])
 	bool pico_ql = false;
 #endif
 
+	vector<const char *> call_graphs;
 	Debug::db_read();
 
-	while ((c = getopt(argc, argv, "3bCcRd:rvEp:m:l:os:" PICO_QL_OPTIONS)) != EOF)
+	while ((c = getopt(argc, argv, "3bCcd:rvEp:m:l:os:R:" PICO_QL_OPTIONS)) != EOF)
 		switch (c) {
 		case '3':
 			Fchar::enable_trigraphs();
@@ -3247,9 +3248,10 @@ main(int argc, char *argv[])
 			db_engine = strdup(optarg);
 			break;
 		case 'R':
-			if (process_mode)
+			if (!optarg)
 				usage(argv[0]);
 			process_mode = pm_r_option;
+			call_graphs.push_back(optarg);
 			break;
 		case '?':
 			usage(argv[0]);
@@ -3433,6 +3435,16 @@ main(int argc, char *argv[])
 		return (0);
 	}
 #endif
+
+	if (process_mode == pm_r_option) {
+		cerr << "Producing call graphs" << endl;
+
+		for (const char *d : call_graphs) {
+			cerr << d << endl;
+		}
+
+		return (0);
+	}
 
 	if (process_mode == pm_compile)
 		return (0);

--- a/src/cscout.cpp
+++ b/src/cscout.cpp
@@ -2358,6 +2358,16 @@ graph_pdf_page(FILE *fo, void (*graph_fun)(GraphDisplay *))
 	graph_fun(&gd);
 }
 
+// Produce call graphs with -R option
+static void produce_call_graphs(const vector <string> &call_graphs)
+{
+
+
+
+
+}
+
+
 // Setup graph handling for all supported graph output types
 static void
 graph_handle(string name, void (*graph_fun)(GraphDisplay *))
@@ -3161,7 +3171,7 @@ main(int argc, char *argv[])
 	bool pico_ql = false;
 #endif
 
-	vector<const char *> call_graphs;
+	vector<string> call_graphs;
 	Debug::db_read();
 
 	while ((c = getopt(argc, argv, "3bCcd:rvEp:m:l:os:R:" PICO_QL_OPTIONS)) != EOF)
@@ -3251,7 +3261,7 @@ main(int argc, char *argv[])
 			if (!optarg)
 				usage(argv[0]);
 			process_mode = pm_r_option;
-			call_graphs.push_back(optarg);
+			call_graphs.push_back(string(optarg));
 			break;
 		case '?':
 			usage(argv[0]);
@@ -3437,11 +3447,10 @@ main(int argc, char *argv[])
 #endif
 
 	if (process_mode == pm_r_option) {
-		cerr << "Producing call graphs" << endl;
-
-		for (const char *d : call_graphs) {
-			cerr << d << endl;
-		}
+		cerr << "Producing call graphs for: ";
+		for (string d : call_graphs) cerr << d;
+		cerr << endl;
+		produce_call_graphs(call_graphs);
 
 		return (0);
 	}

--- a/src/cscout.cpp
+++ b/src/cscout.cpp
@@ -2388,8 +2388,8 @@ vector<string> split_by_delimiter(string &s, char delim) {
 
 	vector<string> tokens; // Create vector to hold our words
 
-	while(getline(ss, buf, delim))
-			tokens.push_back(buf);
+	while (getline(ss, buf, delim))
+		tokens.push_back(buf);
 
 	return tokens;
 }
@@ -2416,32 +2416,32 @@ static void produce_call_graphs(const vector <string> &call_graphs)
 		gd.uses_swill = false;
 		vector<string> opts;
 
-		if (split_base_and_opts.size() == 1) goto call_graph_functions;
+		if (!split_base_and_opts.size() == 1) {
 
-		opts = split_by_delimiter(split_base_and_opts[1], opts_splitter);
+			opts = split_by_delimiter(split_base_and_opts[1], opts_splitter);
 
-		// Parse opts
-		for (string opt: opts) {
-			vector<string> opt_tmp = split_by_delimiter(opt, opt_spltter);
-			if (opt_tmp.size() < 2) continue;
+			// Parse opts
+			for (string opt: opts) {
+				vector<string> opt_tmp = split_by_delimiter(opt, opt_spltter);
+				if (opt_tmp.size() < 2) continue;
 
-			// Key-value pairs
-			string key = opt_tmp[0];
-			string val = opt_tmp[1];
+				// Key-value pairs
+				string key = opt_tmp[0];
+				string val = opt_tmp[1];
 
-			if (!key.compare(gdargskeys.ALL)) {
-				gd.all = (bool) atoi(val.c_str());
-			} else if (!key.compare(gdargskeys.ONLY_VISITED)) {
-				gd.only_visited = (bool) atoi(val.c_str());
-			} else if (!key.compare(gdargskeys.GTYPE)) {
-				gd.gtype = &val[0u];
-			} else if (!key.compare(gdargskeys.LTYPE)) {
-				gd.ltype = &val[0u];
+				if (!key.compare(gdargskeys.ALL)) {
+					gd.all = (bool) atoi(val.c_str());
+				} else if (!key.compare(gdargskeys.ONLY_VISITED)) {
+					gd.only_visited = (bool) atoi(val.c_str());
+				} else if (!key.compare(gdargskeys.GTYPE)) {
+					gd.gtype = &val[0u];
+				} else if (!key.compare(gdargskeys.LTYPE)) {
+					gd.ltype = &val[0u];
+				}
+
 			}
 
 		}
-
-		call_graph_functions:
 
 		if (!base.compare(gdargskeys.CGRAPH)) {
 			cgraph_page(&gd);
@@ -3468,9 +3468,6 @@ main(int argc, char *argv[])
 	}
 
 	if (process_mode != pm_compile) {
-
-
-
 		swill_handle("src.html", source_page, NULL);
 		swill_handle("qsrc.html", query_source_page, NULL);
 		swill_handle("fedit.html", fedit_page, NULL);
@@ -3538,7 +3535,7 @@ main(int argc, char *argv[])
 
 	if (process_mode == pm_r_option) {
 		cerr << "Producing call graphs for: ";
-		for (string d : call_graphs) cerr << d;
+		for (string d : call_graphs) cerr << d << " ";
 		cerr << endl;
 		produce_call_graphs(call_graphs);
 

--- a/src/cscout.cpp
+++ b/src/cscout.cpp
@@ -114,7 +114,8 @@ static enum e_process {
 	pm_compile,			// Compile-only (-c)
 	pm_report,			// Generate a warning report
 	pm_database,
-	pm_obfuscation
+	pm_obfuscation,
+	pm_r_option
 } process_mode;
 static int portno = 8081;		// Port number (-p n)
 static char *db_engine;			// Create SQL output for a specific db_iface
@@ -134,8 +135,6 @@ static Fileid input_file_id;
 // Set to true when the user has specified the application to exit
 static bool must_exit = false;
 
-// Set to true when -R call is supplied from the command line
-static bool has_R_option = false;
 
 // Set to true if we operate in browsing mode
 static bool browse_only = false;
@@ -2298,7 +2297,7 @@ graph_txt_page(FILE *fo, void (*graph_fun)(GraphDisplay *))
 		fclose(ofile);
 	}
 
-	if (!has_R_option) {
+	if (process_mode != pm_r_option) {
 		GDTxt gd(fo);
 		graph_fun(&gd);
 	}
@@ -3250,7 +3249,8 @@ main(int argc, char *argv[])
 		case 'R':
 			if (process_mode)
 				usage(argv[0]);
-			process_mode = pm_compile;
+			process_mode = pm_r_option;
+			break;
 		case '?':
 			usage(argv[0]);
 		}

--- a/src/cscout.cpp
+++ b/src/cscout.cpp
@@ -134,6 +134,9 @@ static Fileid input_file_id;
 // Set to true when the user has specified the application to exit
 static bool must_exit = false;
 
+// Set to true when -R call is supplied from the command line
+static bool has_R_option = false;
+
 // Set to true if we operate in browsing mode
 static bool browse_only = false;
 // Maximum number of nodes and edges allowed to browsing-only clients
@@ -2285,8 +2288,21 @@ end:
 static void
 graph_txt_page(FILE *fo, void (*graph_fun)(GraphDisplay *))
 {
-	GDTxt gd(fo);
-	graph_fun(&gd);
+	// Add output and outfile argument to enable output to outfile
+	int output;
+	char *outfile;
+	if (swill_getargs("i(output)s(outfile)", &output, &outfile) && output && strlen(outfile)) {
+		FILE *ofile = fopen(outfile, "w+");
+		GDTxt gdout(ofile);
+		graph_fun(&gdout);
+		fclose(ofile);
+	}
+
+	if (!has_R_option) {
+		GDTxt gd(fo);
+		graph_fun(&gd);
+	}
+
 }
 
 // Graph: HTML
@@ -3290,6 +3306,8 @@ main(int argc, char *argv[])
 	// Pass 2: Create web pages
 	files = Fileid::files(true);
 
+
+
 	if (process_mode != pm_compile) {
 		swill_handle("sproject.html", select_project_page, 0);
 		swill_handle("replacements.html", replacements_page, 0);
@@ -3348,6 +3366,9 @@ main(int argc, char *argv[])
 	}
 
 	if (process_mode != pm_compile) {
+
+
+
 		swill_handle("src.html", source_page, NULL);
 		swill_handle("qsrc.html", query_source_page, NULL);
 		swill_handle("fedit.html", fedit_page, NULL);

--- a/src/cscout.cpp
+++ b/src/cscout.cpp
@@ -40,9 +40,9 @@
 #include <cstdlib>		// atoi
 #include <cstring>		// strdup
 #include <cerrno>		// errno
+#include <regex.h> // regex
 
 #include <getopt.h>
-#include <regex.h>
 
 #include "swill.h"
 
@@ -2358,10 +2358,33 @@ graph_pdf_page(FILE *fo, void (*graph_fun)(GraphDisplay *))
 	graph_fun(&gd);
 }
 
+
+vector<string> split_by_delimiter(string &s, char delim) {
+	string buf;                 // Have a buffer string
+	stringstream ss(s);       // Insert the string into a stream
+
+	vector<string> tokens; // Create vector to hold our words
+
+	while(getline(ss, buf, delim))
+			tokens.push_back(buf);
+
+	return tokens;
+}
+
+
+
 // Produce call graphs with -R option
 static void produce_call_graphs(const vector <string> &call_graphs)
 {
+	char base_splitter = '?';
 
+	for (string url: call_graphs) {
+		vector<string> split_base_and_opts = split_by_delimiter(url, base_splitter);
+		for (string z: split_base_and_opts) {
+			cerr << z << endl;
+		}
+
+	}
 
 
 

--- a/src/gdisplay.h
+++ b/src/gdisplay.h
@@ -39,6 +39,12 @@ protected:
 	FILE *fo;		// HTTP output file
 	FILE *fdot;		// Dot output file
 public:
+	bool uses_swill = true;
+	bool all = false;
+	bool only_visited = false;
+	char *gtype = NULL;
+	char *ltype = NULL;
+	
 	GraphDisplay(FILE *f) : fo(f), fdot(NULL) {}
 	virtual void head(const char *fname, const char *title, bool empty_node) {};
 	virtual void subhead(const string &text) {};

--- a/src/gdisplay.h
+++ b/src/gdisplay.h
@@ -33,6 +33,7 @@ using namespace std;
 #include "version.h"
 #include "option.h"
 
+
 // Abstract base class, used for drawing
 class GraphDisplay {
 protected:
@@ -44,7 +45,7 @@ public:
 	bool only_visited = false;
 	char *gtype = NULL;
 	char *ltype = NULL;
-	
+
 	GraphDisplay(FILE *f) : fo(f), fdot(NULL) {}
 	virtual void head(const char *fname, const char *title, bool empty_node) {};
 	virtual void subhead(const string &text) {};
@@ -203,3 +204,19 @@ public:
 };
 
 #endif // GDISPLAY_
+
+#ifndef GDARGSKEYS_
+#define GDARGSKEYS_
+
+// Static class for GraphDisplay Arguments Keys for parsing
+class GDArgsKeys {
+public:
+	string CGRAPH = "cgraph.txt";
+	string FGRAPH = "fgraph.txt";
+	string ALL = "all";
+	string ONLY_VISITED = "only_visited";
+	string GTYPE = "gtype";
+	string LTYPE = "ltype";
+};
+
+#endif // GDARGSKEYS_


### PR DESCRIPTION
The -R option can produce the needed call graphs and then exit. 

Example

```
cscout -R cgraph.txt -R fgraph.txt\?gtype\=C awk.cs
```

This PR includes
 - Implementation for the -R option
 - GraphDisplay can have arguments as fields
 - `frgaph_page`, `cgraph_page` can work in a more generic way if swill is not used
 - Manpages updated
