### PR TITLE
Add new GCC built-in definitions

### DIFF
--- a/include/template/gcc-defs.h
+++ b/include/template/gcc-defs.h
@@ -28,6 +28,7 @@
 /* GCC __builtin_* funtions and misc */
 #define asm __asm__
 #define __alignof__(x) (sizeof(x) & 0xf)
+#define _Alignof(x) (sizeof(x) & 0xf)
 #define __attribute__(x)
 #define __builtin_add_overflow(x,y,z) ((x), (y), (z), 1)
 #define __builtin_alloca_with_align_and_max (x,y,z) ((x), (y), (z), 1)
@@ -143,6 +144,13 @@
 #define __extension
 #define __extension__
 #define __int128 long
+#define _Float32 double
+#define _Float32x double
+#define _Float64 double
+#define _Float64x double
 #define __float128 double
+#define _Float128 double
 #define __PRETTY_FUNCTION__ "UNKNOWN"
+#define __restrict
+#define _Static_assert(x)
 #define typeof __typeof__


### PR DESCRIPTION
I tried to generate the call graph for the last version of Coreutils
using csmake to generate the processing script automatically. But when I
executed `cscout -R cgraph.txt?all=1 make.cs` to generate the call graph
it failed with:

```
/usr/include/stdlib.h:140: error: syntax error
The text leading to this error is: [extern _Float32 strtof32]
```

Adding `#define _Float32 float` to include/template/gcc-defs.h solves this
problem.

The definitions for GCC can be found in chapter 5-6-7 in the following
link.

<https://gcc.gnu.org/onlinedocs/gcc/>