### PR TITLE
Add hard_defined pragma to handle special cases

### DIFF
--- a/include/template/gcc-defs.h
+++ b/include/template/gcc-defs.h
@@ -142,7 +142,7 @@
 #define __builtin___vsprintf_chk(x,y,z,w,r) ((x), (y), (z), (w), (r), 1)
 #define __COUNTER__ 0
 #define __extension
-#define __extension__
+#pragma hard_defined __extension__
 #define __int128 long
 #define _Float32 double
 #define _Float32x double

--- a/src/macro.cpp
+++ b/src/macro.cpp
@@ -344,9 +344,10 @@ Macro::register_macro_body(mapMacroBody &map) const
 }
 
 // Constructor
-Macro::Macro( const Ptoken& name, bool id, bool isfun) :
+Macro::Macro( const Ptoken& name, bool id, bool isfun, bool ishard) :
 	name_token(name),
 	is_function(isfun),
+	is_hard(ishard),
 	is_vararg(false),
 	is_defined(id)
 {

--- a/src/macro.h
+++ b/src/macro.h
@@ -57,17 +57,19 @@ private:
 	bool is_vararg;			// True if the function has variable # of arguments (gcc)
 	bool is_defined;		// True if the macro has been defined
 					// Can be false through ifdef/ifndef/defined()
+	bool is_hard;			// Hard-defined macro that annot be undef'd
 	dequePtoken formal_args;	// Formal arguments (names)
 	dequePtoken value;		// Macro value
 	MCall *mcall;			// Function call info
 public:
-	Macro( const Ptoken& name, bool id, bool is_function);
+	Macro( const Ptoken& name, bool id, bool is_function, bool is_hard);
 	// Accessor functions
 	const Ptoken& get_name_token() const {return name_token; };
 	void set_is_function(bool v) { is_function = v; };
 	void set_is_vararg(bool v) { is_vararg = v; };
 	bool get_is_defined() const { return is_defined; };
 	bool get_is_vararg() const { return is_vararg; };
+	bool get_is_hard() const { return is_hard; };
 	// Return the number of formal arguments
 	int get_num_args() const { return formal_args.size(); }
 	void form_args_push_back(Ptoken& t) { formal_args.push_back(t); };

--- a/src/pdtoken.h
+++ b/src/pdtoken.h
@@ -76,7 +76,7 @@ private:
 	static void process_directive();	// Handle a cpp directive
 	static void eat_to_eol();		// Consume input including \n
 	static void process_include(bool next);	// Handle a #include
-	static void process_define();		// Handle a #define
+	static void process_define(bool ishard);// Handle a #define
 	static void process_undef();		// Handle a #undef
 	static void process_if();		// Handle #if
 	static void process_ifdef(bool isndef);	// Handle #ifdef/ndef


### PR DESCRIPTION
When tried to generate the call graph for the last version of Coreutils,
using csmake to generate the processing script automatically, the
following error occurred.

```
/usr/include/stdlib.h:76: error: syntax error
The text leading to this error is: [__extension__ typedef]
```

To solve this error normally, we'll add the `#define __extension__` to
`include/template/gcc-defs`, but when we did it, the error didn't
resolve. The reason was that somewhere in Coreutils, there was an
`undef` for `__extension__`. To handle that, we need to block `undef`
for some specific defines. To do so, we added a new pragma directive,
called hard_defined.