### PR TITLE
Fix bug and add one more option to -R command line option

### DIFF
--- a/src/cscout.cpp
+++ b/src/cscout.cpp
@@ -2439,6 +2439,9 @@ static void produce_call_graphs(const vector <string> &call_graphs)
 					gd.gtype = strdup(val.c_str());
 				} else if (!key.compare(gdargskeys.LTYPE)) {
 					gd.ltype = strdup(val.c_str());
+					Option::cgraph_show->set_hard(val.c_str());
+				} else if (!key.compare("type")) {
+					Option::show_function_type->set_hard((bool) atoi(val.c_str()));
 				}
 
 			}

--- a/src/html.cpp
+++ b/src/html.cpp
@@ -240,6 +240,12 @@ function_label(Call *f, bool hyperlink)
 		snprintf(buff, sizeof(buff), "<a href=\"fun.html?f=%p\">", f);
 		result = buff;
 	}
+	if (Option::show_function_type->get()) {
+		if (f->is_file_scoped())
+			result += "static:";	
+		else
+			result += "public:";	
+	}
 	if (Option::cgraph_show->get() == 'f')		// Show files
 		result += f->get_site().get_fileid().get_fname() + ":";
 	else if (Option::cgraph_show->get() == 'p')	// Show paths

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -58,6 +58,7 @@ IntegerOption *Option::tab_width;		// Tab width for code output
 TextOption *Option::dot_graph_options;		// Graph options passed to dot
 TextOption *Option::dot_node_options;		// Node options passed to dot
 TextOption *Option::dot_edge_options;		// Edge options passed to dot
+BoolOption *Option::show_function_type;		// Show function type (static or public)
 SelectionOption *Option::cgraph_type;		// Call graph type t(text h(tml d(ot s(vg g(if
 SelectionOption *Option::cgraph_show;		// Call graph show e(dge n(ame f(ile p(ath
 SelectionOption *Option::fgraph_show;		// File graph show e)dge n(ame p(ath
@@ -233,6 +234,7 @@ Option::initialize()
 	Option::add(sort_rev = new BoolOption("sort_rev", "Sort identifiers starting from their last character"));
 
 	Option::add(new TitleOption("Call and File Dependency Graphs"));
+	Option::add(show_function_type = new BoolOption("show_function_type", "Show function type (static or public)"));
 	Option::add(cgraph_type = new SelectionOption("cgraph_type", "Graph links should lead to pages of:", 's',
 		"d:dot",
 		"g:GIF",

--- a/src/option.h
+++ b/src/option.h
@@ -90,6 +90,7 @@ public:
 	static TextOption *dot_graph_options;		// Graph options passed to dot
 	static TextOption *dot_node_options;		// Node options passed to dot
 	static TextOption *dot_edge_options;		// Edge options passed to dot
+	static BoolOption *show_function_type;		// Show function type (static or public)
 	static SelectionOption *cgraph_type;		// Call graph type t(text h(tml d(ot s(vg g(if
 	static SelectionOption *cgraph_show;		// Call graph show e(dge n(ame f(ile p(ath
 	static SelectionOption *fgraph_show;		// File graph show e(dge n(ame p(ath
@@ -117,6 +118,10 @@ public:
 	void load(ifstream &ifs) { ifs >> v; }
 	// Set from a submitted page
 	void set() { v = !!swill_getvar(short_name); }
+	// Set from command line: option -R
+	void set_hard(bool m) {
+		v = m;
+	}
 	// Set from a submitted page
 	bool get() { return v; }
 	// Display on a web page
@@ -159,6 +164,10 @@ public:
 
 		if ((m = swill_getvar(short_name)))
 			v = *m;
+	}
+	// Set from command line: option -R
+	void set_hard(const char* m) {
+		v = *m;
 	}
 	// Return the value
 	char get() { return v; }

--- a/src/pdtoken.cpp
+++ b/src/pdtoken.cpp
@@ -864,7 +864,7 @@ Pdtoken::process_define(bool is_immutable)
 		if (lead && t.is_space()) {
 			if (t.get_code() == SPACE)
 				t.getnext<Fchar>();
-			if (t.get_code() == '\n')
+			if (t.get_code() == '\n') 
 				break;
 			continue;
 		}


### PR DESCRIPTION
When we called CScout with the `-R cgraph.txt?n=p` the `n=p`
does not have any effect because in the `function_label` function the
`cgraph_show` is read from `Option::show_function_type`. To fix this issue
I set the value of `n` with a new setter function directly on
`Option::cgraph_show`.

The new option is the `show_function_type` option with which a prefix of
`static:` or `public:`, based on function type,  is added to nodes in
call graphs. To enable it from the command line you should pass `type=1`.
For example, `cscout -R cgraph.txt?n=p&type=1 make.cs`