### PR TITLE
Add option to print if a function is defined

### DIFF
--- a/src/cscout.cpp
+++ b/src/cscout.cpp
@@ -2442,6 +2442,8 @@ static void produce_call_graphs(const vector <string> &call_graphs)
 					Option::cgraph_show->set_hard(val.c_str());
 				} else if (!key.compare("type")) {
 					Option::show_function_type->set_hard((bool) atoi(val.c_str()));
+				} else if (!key.compare("defined")) {
+					Option::is_defined->set_hard((bool) atoi(val.c_str()));
 				}
 
 			}

--- a/src/html.cpp
+++ b/src/html.cpp
@@ -246,6 +246,12 @@ function_label(Call *f, bool hyperlink)
 		else
 			result += "public:";	
 	}
+	if (Option::is_defined->get()) {
+		if (f->is_defined())
+			result += "1:";	
+		else
+			result += "0:";	
+	}
 	if (Option::cgraph_show->get() == 'f')		// Show files
 		result += f->get_site().get_fileid().get_fname() + ":";
 	else if (Option::cgraph_show->get() == 'p')	// Show paths

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -59,6 +59,7 @@ TextOption *Option::dot_graph_options;		// Graph options passed to dot
 TextOption *Option::dot_node_options;		// Node options passed to dot
 TextOption *Option::dot_edge_options;		// Edge options passed to dot
 BoolOption *Option::show_function_type;		// Show function type (static or public)
+BoolOption *Option::is_defined;				// Show if a function is defined or not (0: for not define, 1: for defined)
 SelectionOption *Option::cgraph_type;		// Call graph type t(text h(tml d(ot s(vg g(if
 SelectionOption *Option::cgraph_show;		// Call graph show e(dge n(ame f(ile p(ath
 SelectionOption *Option::fgraph_show;		// File graph show e)dge n(ame p(ath
@@ -235,6 +236,7 @@ Option::initialize()
 
 	Option::add(new TitleOption("Call and File Dependency Graphs"));
 	Option::add(show_function_type = new BoolOption("show_function_type", "Show function type (static or public)"));
+	Option::add(is_defined = new BoolOption("is_defined", "Show if a function is defined or not (0: for not define, 1: for defined)"));
 	Option::add(cgraph_type = new SelectionOption("cgraph_type", "Graph links should lead to pages of:", 's',
 		"d:dot",
 		"g:GIF",

--- a/src/option.h
+++ b/src/option.h
@@ -91,6 +91,7 @@ public:
 	static TextOption *dot_node_options;		// Node options passed to dot
 	static TextOption *dot_edge_options;		// Edge options passed to dot
 	static BoolOption *show_function_type;		// Show function type (static or public)
+	static BoolOption *is_defined;				// Show if a function is defined or not (0: for not define, 1: for defined)
 	static SelectionOption *cgraph_type;		// Call graph type t(text h(tml d(ot s(vg g(if
 	static SelectionOption *cgraph_show;		// Call graph show e(dge n(ame f(ile p(ath
 	static SelectionOption *fgraph_show;		// File graph show e(dge n(ame p(ath


### PR DESCRIPTION
Add new option `is_defined` that prints if CScout detected the definition of
a function or not. If the function is defined, add as a prefix to a node `1:` else
add `0:`. To use this option from the command line, add `defined=1` in `-R`
option.

For example, `cscout -R "cgraph.txt?all=1&n=p&type=1&defined=1" will produce
call graphs with the following format for edges:

`public:1:/home/debian/mwe1/t.c:square public:0:/usr/include/stdio.h:printf`