### PR TITLE
Add option to print all defined nodes

### DIFF
--- a/src/cscout.cpp
+++ b/src/cscout.cpp
@@ -2444,6 +2444,8 @@ static void produce_call_graphs(const vector <string> &call_graphs)
 					Option::show_function_type->set_hard((bool) atoi(val.c_str()));
 				} else if (!key.compare("defined")) {
 					Option::is_defined->set_hard((bool) atoi(val.c_str()));
+				} else if (!key.compare("nodes")) {
+					Option::print_nodes->set_hard((bool) atoi(val.c_str()));
 				}
 
 			}

--- a/src/gdisplay.h
+++ b/src/gdisplay.h
@@ -100,6 +100,11 @@ public:
 class GDTxt: public GraphDisplay {
 public:
 	GDTxt(FILE *f) : GraphDisplay(f) {}
+       virtual void node(Call *p) {
+               if (Option::print_nodes->get() && p->is_defined()) {
+                       fprintf(fo, "%s\n", function_label(p, false).c_str());
+               }
+       }
 	virtual void edge(Call *a, Call *b) {
 		fprintf(fo, "%s %s\n",
 		    function_label(a, false).c_str(),

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -58,8 +58,9 @@ IntegerOption *Option::tab_width;		// Tab width for code output
 TextOption *Option::dot_graph_options;		// Graph options passed to dot
 TextOption *Option::dot_node_options;		// Node options passed to dot
 TextOption *Option::dot_edge_options;		// Edge options passed to dot
-BoolOption *Option::show_function_type;		// Show function type (static or public)
-BoolOption *Option::is_defined;				// Show if a function is defined or not (0: for not define, 1: for defined)
+BoolOption *Option::show_function_type;     // Show function type (static or public)
+BoolOption *Option::is_defined;             // Show if a function is defined or not (0: for not define, 1: for defined)
+BoolOption *Option::print_nodes;            // Print defined nodes (as edges with only one node) in the begin
 SelectionOption *Option::cgraph_type;		// Call graph type t(text h(tml d(ot s(vg g(if
 SelectionOption *Option::cgraph_show;		// Call graph show e(dge n(ame f(ile p(ath
 SelectionOption *Option::fgraph_show;		// File graph show e)dge n(ame p(ath
@@ -237,6 +238,7 @@ Option::initialize()
 	Option::add(new TitleOption("Call and File Dependency Graphs"));
 	Option::add(show_function_type = new BoolOption("show_function_type", "Show function type (static or public)"));
 	Option::add(is_defined = new BoolOption("is_defined", "Show if a function is defined or not (0: for not define, 1: for defined)"));
+	Option::add(print_nodes = new BoolOption("print_nodes", "Print defined nodes (as edges with only one node) in the begin"));
 	Option::add(cgraph_type = new SelectionOption("cgraph_type", "Graph links should lead to pages of:", 's',
 		"d:dot",
 		"g:GIF",

--- a/src/option.h
+++ b/src/option.h
@@ -92,6 +92,7 @@ public:
 	static TextOption *dot_edge_options;		// Edge options passed to dot
 	static BoolOption *show_function_type;		// Show function type (static or public)
 	static BoolOption *is_defined;				// Show if a function is defined or not (0: for not define, 1: for defined)
+	static BoolOption *print_nodes;				// Print defined nodes (as edges with only one node) in the begin
 	static SelectionOption *cgraph_type;		// Call graph type t(text h(tml d(ot s(vg g(if
 	static SelectionOption *cgraph_show;		// Call graph show e(dge n(ame f(ile p(ath
 	static SelectionOption *fgraph_show;		// File graph show e(dge n(ame p(ath


### PR DESCRIPTION
Add new option `print_nodes` that prints all defined nodes as edges with
a single node. To use this option from the command line, add `nodes=1`
in `-R` option.

For instance, `cscout -R "cgraph.txt?all=1&n=p&type=1&nodes=1" will
produce call graphs with the following format:

```
public:/home/debian/mwe1/t.c:square
public:/home/debian/mwe1/t.c:print_square
public:/home/debian/mwe1/t.c:square public:/usr/include/stdio.h:printf
```