### PR TITLE
Add option to print the line numbers of a function

### DIFF
--- a/src/cscout.cpp
+++ b/src/cscout.cpp
@@ -2444,6 +2444,8 @@ static void produce_call_graphs(const vector <string> &call_graphs)
 					Option::show_function_type->set_hard((bool) atoi(val.c_str()));
 				} else if (!key.compare("defined")) {
 					Option::is_defined->set_hard((bool) atoi(val.c_str()));
+				} else if (!key.compare("nline")) {
+					Option::line_num->set_hard((bool) atoi(val.c_str()));
 				} else if (!key.compare("nodes")) {
 					Option::print_nodes->set_hard((bool) atoi(val.c_str()));
 				}

--- a/src/html.cpp
+++ b/src/html.cpp
@@ -242,15 +242,26 @@ function_label(Call *f, bool hyperlink)
 	}
 	if (Option::show_function_type->get()) {
 		if (f->is_file_scoped())
-			result += "static:";	
+			result += "static:";
 		else
-			result += "public:";	
+			result += "public:";
 	}
 	if (Option::is_defined->get()) {
 		if (f->is_defined())
-			result += "1:";	
+			result += "1:";
 		else
-			result += "0:";	
+			result += "0:";
+	}
+	if (Option::line_num->get()) {
+        Tokid t;
+		if (f->is_defined()) {
+            t = f->get_definition();
+        } else {
+            t = f->get_tokid();
+        }
+        int first = t.get_fileid().line_number(t.get_streampos());
+        int last = first + f->metrics().get_metric(Metrics::em_nline);
+        result += to_string(first) + ";" + to_string(last) + ":";
 	}
 	if (Option::cgraph_show->get() == 'f')		// Show files
 		result += f->get_site().get_fileid().get_fname() + ":";

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -60,6 +60,7 @@ TextOption *Option::dot_node_options;		// Node options passed to dot
 TextOption *Option::dot_edge_options;		// Edge options passed to dot
 BoolOption *Option::show_function_type;     // Show function type (static or public)
 BoolOption *Option::is_defined;             // Show if a function is defined or not (0: for not define, 1: for defined)
+BoolOption *Option::line_num;             // Show the first and the last line of a function
 BoolOption *Option::print_nodes;            // Print defined nodes (as edges with only one node) in the begin
 SelectionOption *Option::cgraph_type;		// Call graph type t(text h(tml d(ot s(vg g(if
 SelectionOption *Option::cgraph_show;		// Call graph show e(dge n(ame f(ile p(ath
@@ -238,6 +239,7 @@ Option::initialize()
 	Option::add(new TitleOption("Call and File Dependency Graphs"));
 	Option::add(show_function_type = new BoolOption("show_function_type", "Show function type (static or public)"));
 	Option::add(is_defined = new BoolOption("is_defined", "Show if a function is defined or not (0: for not define, 1: for defined)"));
+	Option::add(line_num = new BoolOption("line_num", "Show the first and the last line of a function"));
 	Option::add(print_nodes = new BoolOption("print_nodes", "Print defined nodes (as edges with only one node) in the begin"));
 	Option::add(cgraph_type = new SelectionOption("cgraph_type", "Graph links should lead to pages of:", 's',
 		"d:dot",

--- a/src/option.h
+++ b/src/option.h
@@ -92,6 +92,7 @@ public:
 	static TextOption *dot_edge_options;		// Edge options passed to dot
 	static BoolOption *show_function_type;		// Show function type (static or public)
 	static BoolOption *is_defined;				// Show if a function is defined or not (0: for not define, 1: for defined)
+	static BoolOption *line_num;				// Show the first and the last line of a function
 	static BoolOption *print_nodes;				// Print defined nodes (as edges with only one node) in the begin
 	static SelectionOption *cgraph_type;		// Call graph type t(text h(tml d(ot s(vg g(if
 	static SelectionOption *cgraph_show;		// Call graph show e(dge n(ame f(ile p(ath


### PR DESCRIPTION
Add new option `nline` that prints the line numbers of a function.
Specifically, it prints the first and the last line separated by a
semicolon (i.e., `"first;last"`). To use this option from the command
line, add `nline=1` in `-R` option.

For instance, `cscout -R "cgraph.txt?all=1&n=p&type=1&nodes=1&nline=1"` will
produce call graphs with nodes in the following format.

`static:1:38;39:/home/user/cscout/example/awk/awk.h:dprintf`