### PR TITLE
Add new GCC built-in definitions and ifdef for llvm definitions

### DIFF
--- a/include/template/gcc-defs.h
+++ b/include/template/gcc-defs.h
@@ -29,7 +29,14 @@
 #define asm __asm__
 #define __alignof__(x) (sizeof(x) & 0xf)
 #define _Alignof(x) (sizeof(x) & 0xf)
+#define _Atomic
+#define __atomic_fetch_add(x,y) *x+=y
+#define __atomic_fetch_add_explicit(x,y,z) *x+=y
+#define __atomic_fetch_sub(x,y) *x-=y
+#define __atomic_fetch_sub_explicit(x,y,z) *x-=y
+#define __atomic_thread_fence(x)
 #define __attribute__(x)
+#define __auto_type auto
 #define __builtin_add_overflow(x,y,z) ((x), (y), (z), 1)
 #define __builtin_add_overflow_p(x,y,z) ((x), (y), 1)
 #define __builtin_alloca_with_align_and_max (x,y,z) ((x), (y), (z), 1)
@@ -149,12 +156,14 @@
 #pragma define_immutable __extension__
 #define __int128 long
 #define __int128_t long
+#define __uint128_t long
 #define _Float32 float
 #define _Float32x float
 #define _Float64 double
 #define _Float64x double
 #define __float128 double
 #define _Float128 double
+#define _Noreturn
 #define __PRETTY_FUNCTION__ "UNKNOWN"
 #define typeof __typeof__
 #pragma define_immutable __restrict

--- a/include/template/gcc-defs.h
+++ b/include/template/gcc-defs.h
@@ -31,6 +31,7 @@
 #define _Alignof(x) (sizeof(x) & 0xf)
 #define __attribute__(x)
 #define __builtin_add_overflow(x,y,z) ((x), (y), (z), 1)
+#define __builtin_add_overflow_p(x,y,z) ((x), (y), 1)
 #define __builtin_alloca_with_align_and_max (x,y,z) ((x), (y), (z), 1)
 #define __builtin_alloca_with_align (x,y) ((x), (y), 1)
 #define __builtin_alloca(x) ((x), 1)
@@ -87,6 +88,7 @@
 #define __builtin_memset(x,y,z) ((x), (y), (z), 1)
 #define __builtin___memset_chk(x,y,z,w) ((x), (y), (z), (w), 0)
 #define __builtin_mul_overflow(x,y,z) ((x), (y), (z), 1)
+#define __builtin_mul_overflow_p(x,y,z) ((x), (y), 1)
 #define __builtin_nand128(x) ((x), 1.)
 #define __builtin_nand32(x) ((x), 1f)
 #define __builtin_nand64(x) ((x), 1.)
@@ -126,6 +128,8 @@
 #define __builtin_strlen(x) ((x), 1)
 #define __builtin___strncat_chk(x,y,z,w) ((x), (y), (z), (w), 1)
 #define __builtin___strncpy_chk(x,y,z,w) ((x), (y), (z), (w), 1)
+#define __builtin_sub_overflow(x,y,z) ((x), (y), (z), 1)
+#define __builtin_sub_overflow_p(x,y,z) ((x), (y), 1)
 #define __builtin_tgmath(x, y) ((x), (y), 0)
 #define __builtin_trap() 1
 #define __builtin_types_compatible_p(x,y) (1)
@@ -152,6 +156,7 @@
 #define __float128 double
 #define _Float128 double
 #define __PRETTY_FUNCTION__ "UNKNOWN"
-#define _Static_assert(x)
 #define typeof __typeof__
 #pragma define_immutable __restrict
+
+#pragma define_immutable _Static_assert(x)

--- a/include/template/gcc-defs.h
+++ b/include/template/gcc-defs.h
@@ -30,10 +30,10 @@
 #define __alignof__(x) (sizeof(x) & 0xf)
 #define _Alignof(x) (sizeof(x) & 0xf)
 #define _Atomic
-#define __atomic_fetch_add(x,y) *x+=y
-#define __atomic_fetch_add_explicit(x,y,z) *x+=y
-#define __atomic_fetch_sub(x,y) *x-=y
-#define __atomic_fetch_sub_explicit(x,y,z) *x-=y
+#define __atomic_fetch_add(x,y) (*(x)+=(y))
+#define __atomic_fetch_add_explicit(x,y,z) (*(x)+=(y))
+#define __atomic_fetch_sub(x,y) (*(x)-=(y))
+#define __atomic_fetch_sub_explicit(x,y,z) (*(x)-=(y))
 #define __atomic_thread_fence(x)
 #define __attribute__(x)
 #define __auto_type auto

--- a/include/template/llvm-defs.h
+++ b/include/template/llvm-defs.h
@@ -20,9 +20,11 @@
  * See http://clang.llvm.org/docs/AttributeReference.html
  */
 
+#ifdef __clang__
 #define _Noreturn
 #define _Nonnull
 #define _Null_unspecified
 #define _Nullable
 
 #define __has_include_next(x) 0
+#endif


### PR DESCRIPTION
Add support for the following definitions:

* Atomic [definitions](https://en.cppreference.com/w/cpp/atomic)
* `__auto_type`
* `_Noreturn`

Add `ifdef __clang__` for llvm definitions to prevent some redefinition warnings.