### PR TITLE
Refactor: Modernize query sorting with stateful lambda comparators

### DIFF
--- a/src/cscout.cpp
+++ b/src/cscout.cpp
@@ -1051,7 +1051,7 @@ xfilequery_page(FILE *of,  void *)
 	if (!query.is_valid())
 		return 0;
 
-	multiset <Fileid, FileQuery::specified_order> sorted_files;
+	multiset <Fileid, FileQuery::FileComparator> sorted_files(query.get_comparator());
 
 	html_head(of, "xfilequery", (qname && *qname) ? qname : "File Query Results");
 
@@ -1066,7 +1066,7 @@ xfilequery_page(FILE *of,  void *)
 		fprintf(of, "<th>%s</th>\n", Metrics::get_name<FileMetrics>(query.get_sort_order()).c_str());
 	Pager pager(of, Option::entries_per_page->get(), query.base_url(), query.bookmarkable());
 	html_file_set_begin(of);
-	for (multiset <Fileid, FileQuery::specified_order>::iterator i = sorted_files.begin(); i != sorted_files.end(); i++) {
+	for (multiset <Fileid, FileQuery::FileComparator>::iterator i = sorted_files.begin(); i != sorted_files.end(); i++) {
 		Fileid f = *i;
 		if (current_project && !Filedetails::get_attribute(f, current_project))
 			continue;
@@ -1346,7 +1346,9 @@ xiquery_page(FILE *of,  void *)
 		display_files(of, query, sorted_files);
 	if (q_fun) {
 		fputs("<h2>Matching Functions</h2>\n", of);
-		Sfuns sorted_funs;
+		Sfuns sorted_funs([](const Call *a, const Call *b) {
+			return Query::string_bi_compare(a->get_name(), b->get_name());
+		});
 		sorted_funs.insert(funs.begin(), funs.end());
 		display_sorted(of, query, sorted_funs);
 	}
@@ -1363,12 +1365,12 @@ xfunquery_page(FILE *of,  void *)
 	prohibit_remote_access(of);
 	Timer timer;
 
-	Sfuns sorted_funs;
 	IFSet sorted_files;
 	bool q_id = !!swill_getvar("qi");	// Show matching identifiers
 	bool q_file = !!swill_getvar("qf");	// Show matching files
 	char *qname = swill_getvar("n");
 	FunQuery query(of, Option::file_icase->get(), current_project);
+	Sfuns sorted_funs(query.get_comparator());
 
 	if (!query.is_valid())
 		return 0;

--- a/src/filequery.cpp
+++ b/src/filequery.cpp
@@ -56,9 +56,6 @@
 #include "filequery.h"
 
 
-int FileQuery::specified_order::order;
-bool FileQuery::specified_order::reverse;
-
 // Construct an object based on URL parameters
 FileQuery::FileQuery(FILE *of, bool icase, Attributes::size_type cp, bool e, bool r) :
 	Query(!e, r, true),
@@ -92,7 +89,6 @@ FileQuery::FileQuery(FILE *of, bool icase, Attributes::size_type cp, bool e, boo
 	// Compile regular expression specs
 	if (!compile_re(of, "Filename", "fre", fre, match_fre, str_fre, (icase ? REG_ICASE : 0)))
 	    	return;
-	specified_order::set_order(mquery.get_sort_order(), mquery.get_reverse());
 }
 
 // Return the URL for re-executing this query

--- a/src/filequery.h
+++ b/src/filequery.h
@@ -25,6 +25,7 @@
 #define FILEQUERY_
 
 #include <string>
+#include <functional>
 
 using namespace std;
 
@@ -96,6 +97,24 @@ public:
 	int get_sort_order() const { return mquery.get_sort_order(); }
 	// Return true if the query's URL can be bookmarked across CScout invocations
 	bool bookmarkable() const { return true; }
+
+	// Modern C++11 comparator type using std::function
+	using FileComparator = std::function<bool(const Fileid &, const Fileid &)>;
+
+	// Returns a comparator capturing the current sort order
+	FileComparator get_comparator() const {
+		int o = mquery.get_sort_order();
+		bool r = mquery.get_reverse();
+		return [o, r](const Fileid &a, const Fileid &b) {
+			bool val;
+			if (o == -1)
+				val = (a.get_path() < b.get_path());
+			else
+				val = (Filedetails::get_pre_cpp_const_metrics(a).get_metric(o) <
+					Filedetails::get_pre_cpp_const_metrics(b).get_metric(o));
+			return r ? !val : val;
+		};
+	}
 };
 
 #endif // FILEQUERY_

--- a/src/filequery.h
+++ b/src/filequery.h
@@ -55,31 +55,6 @@ private:
 	MQuery<FileMetrics, Fileid &> mquery;
 
 public:
-	// Container comparison functor
-	class specified_order {
-	private:
-		/*
-		 * Can only be an instance variable (per C++ PL 17.1.4.5)
-		 * only when the corresponding constructor is passed a
-		 * compile-time constant.
-		 * This hack works around the limitation.
-		 */
-		static int order;
-		static bool reverse;
-	public:
-		// Should be called exactly once before instantiating the set
-		static void set_order(int o, bool r) { order = o; reverse = r; }
-		bool operator()(const Fileid &a, const Fileid &b) const {
-			bool val;
-			if (order == -1)
-				// Order by name
-				val = (a.get_path() < b.get_path());
-			else
-				val = (Filedetails::get_pre_cpp_const_metrics(a).get_metric(order) < Filedetails::get_pre_cpp_const_metrics(b).get_metric(order));
-			return reverse ? !val : val;
-		}
-	};
-
 	// Construct object based on URL parameters
 	FileQuery(FILE *f, bool icase, Attributes::size_type current_project, bool e = true, bool r = true);
 	// Default

--- a/src/funquery.cpp
+++ b/src/funquery.cpp
@@ -71,9 +71,6 @@
 #include "mquery.h"
 #include "funquery.h"
 
-int FunQuery::specified_order::order;
-bool FunQuery::specified_order::reverse;
-
 // Construct an object based on URL parameters
 FunQuery::FunQuery(FILE *of, bool icase, Attributes::size_type cp, bool e, bool r) :
 	Query(!e, r, true),
@@ -141,7 +138,6 @@ FunQuery::FunQuery(FILE *of, bool icase, Attributes::size_type cp, bool e, bool 
 	    !compile_re(of, "Called function name", "fdre", fdre, match_fdre, str_fdre) ||
 	    !compile_re(of, "Filename", "fre", fre, match_fre, str_fre, (icase ? REG_ICASE : 0)))
 	    	return;
-	specified_order::set_order(mquery.get_sort_order(), mquery.get_reverse());
 }
 
 // Return the URL for re-executing this query

--- a/src/funquery.h
+++ b/src/funquery.h
@@ -25,6 +25,7 @@
 #define FUNQUERY_
 
 #include <string>
+#include <functional>
 
 using namespace std;
 
@@ -122,8 +123,26 @@ public:
 	int get_sort_order() const { return mquery.get_sort_order(); }
 	// Return true if the query's URL can be bookmarked across CScout invocations
 	bool bookmarkable() const { return id_ec == NULL; }
+
+	// Modern C++11 comparator type using std::function
+	using FunComparator = std::function<bool(const Call *, const Call *)>;
+
+	// Returns a comparator capturing the current sort order
+	FunComparator get_comparator() const {
+		int o = mquery.get_sort_order();
+		bool r = mquery.get_reverse();
+		return [o, r](const Call *a, const Call *b) {
+			bool val;
+			if (o == -1)
+				val = Query::string_bi_compare(a->get_name(), b->get_name());
+			else
+				val = (a->get_pre_cpp_const_metrics().get_metric(o) <
+					b->get_pre_cpp_const_metrics().get_metric(o));
+			return r ? !val : val;
+		};
+	}
 };
 
-typedef multiset <const Call *, FunQuery::specified_order> Sfuns;
+typedef multiset <const Call *, FunQuery::FunComparator> Sfuns;
 
 #endif // FUNQUERY_

--- a/src/funquery.h
+++ b/src/funquery.h
@@ -95,31 +95,7 @@ public:
 	string base_url() const;
 	// Return the query's parameters as a URL
 	string param_url() const;
-	//
-	// Container comparison functor
-	class specified_order {
-	private:
-		/*
-		 * Can only be an instance variable (per C++ PL 17.1.4.5)
-		 * only when the corresponding constructor is passed a
-		 * compile-time constant.
-		 * This hack works around the limitation.
-		 */
-		static int order;
-		static bool reverse;
-	public:
-		// Should be called exactly once before instantiating the set
-		static void set_order(int o, bool r) { order = o; reverse = r; }
-		bool operator()(const Call *a, const Call *b) const {
-			bool val;
-			if (order == -1)
-				// Order by name
-				val = Query::string_bi_compare(a->get_name(), b->get_name());
-			else
-				val = (a->get_pre_cpp_const_metrics().get_metric(order) < b->get_pre_cpp_const_metrics().get_metric(order));
-			return reverse ? !val : val;
-		}
-	};
+
 	int get_sort_order() const { return mquery.get_sort_order(); }
 	// Return true if the query's URL can be bookmarked across CScout invocations
 	bool bookmarkable() const { return id_ec == NULL; }


### PR DESCRIPTION
While working on the codebase, I noticed a comment in `filequery.h` and 
`funquery.h` that said:

> "This hack works around the limitation."

The hack in question was the `specified_order` class, which used static 
variables to store sort order state:
```cpp
static int order;
static bool reverse;
```

Because these are static, they are shared across all query instances. This 
means the sort order is global state, if two queries ever run with different 
sort orders, one will silently corrupt the other's state. On top of that, 
`set_order()` must be called before instantiating the multiset, which is a 
fragile hidden dependency.

## What I changed

- Added `get_comparator()` method to both `FileQuery` and `FunQuery` that 
returns a lambda capturing the sort order locally per query instance
- Added `FileComparator` type in `filequery.h` and `FunComparator` in `funquery.h`
- Updated `Sfuns` typedef to use `FunComparator`
- Updated `cscout.cpp` to pass the comparator directly at multiset construction
- Removed the old `specified_order` class, its static variable definitions, 
and the `set_order()` calls entirely from all four files

The sorting logic itself is unchanged.

## Verification

Built and ran the full test suite in a GitHub Codespace. All 234 tests pass.