### PR TITLE
fix: prevent fork explosion in csmerge.sh for invalid nfiles values

### DIFF
--- a/src/csmerge/csmerge.sh
+++ b/src/csmerge/csmerge.sh
@@ -297,6 +297,18 @@ fi
 NFILES="$1"
 MERGED="$2"
 
+case "$NFILES" in
+  ''|*[!0-9]*)
+    echo "Error: nfiles must be a positive integer." 1>&2
+    usage
+    ;;
+esac
+
+if [ "$NFILES" -lt 2 ] ; then
+  echo "Error: nfiles must be at least 2." 1>&2
+  usage
+fi
+
 # Get dbids from N+1 onward. 1-N are the databases to merge.
 echo $((NFILES + 1)) >$DBID_FILE
 


### PR DESCRIPTION
Fix fork explosion in csmerge.sh for invalid nfiles values

## Problem
`csmerge.sh` assumes `nfiles >= 2`.  
When this is not true:

- `nfiles = 1` leads to infinite recursion and background process spawning (fork explosion)
- Non-numeric values cause a shell error due to `set -u`

## Solution
Add early validation to:
- ensure `nfiles` is numeric
- require `nfiles >= 2`

Invalid input now exits with a clear error message and usage.

## Impact
- Prevents process exhaustion (fork errors)
- Avoids unbound variable crashes
- Improves script robustness

## Reproduction

Before:
- `csmerge.sh 1 merged.db` → fork errors / hang  
- `csmerge.sh abc merged.db` → unbound variable  

After:
- clean validation errors for both cases