### PR TITLE
Correct left-shift signedness to follow left operand 

### DIFF
--- a/src/eval.y
+++ b/src/eval.y
@@ -147,10 +147,17 @@ additive_expression
 
 shift_expression
         : additive_expression
-        | shift_expression LEFT_OP additive_expression	{ binop($$, $1, <<, $3); }
+        | shift_expression LEFT_OP additive_expression
+			{
+				$$.su = $1.su;
+				if ($1.su == e_signed)
+					$$.v.s = ($1.v.s << $3.v.u);
+				else
+					$$.v.u = ($1.v.u << $3.v.u);
+			}
         | shift_expression RIGHT_OP additive_expression
 			{
-			$$.su = $1.su;
+				$$.su = $1.su;
 				if ($1.su == e_signed)
 					$$.v.s = ($1.v.s >> $3.v.u);
 				else


### PR DESCRIPTION
## Problem

The `<<` operator used `binop($$, $1, <<, $3)`, which computes result signedness as:

```c
res.su = (x.su == y.su) ? x.su : e_unsigned;
```

This returns `e_unsigned` when the left operand is signed and the right operand is unsigned (e.g., `signed_val << 2u`). The result is then treated as unsigned in downstream constant expression evaluation, which can silently flip the sign of preprocessor conditionals.

## Fix

Per C11 §6.5.7:
> "The integer promotions are performed on each of the operands. The type of the result is that of the **promoted left operand**."

The right operand's type plays no role in the result type. The fix mirrors what was done for `RIGHT_OP` in #110:

```c
$$.su = $1.su;
if ($1.su == e_signed)
    $$.v.s = ($1.v.s << $3.v.u);
else
    $$.v.u = ($1.v.u << $3.v.u);
```

Both shift operators now consistently derive their result signedness from the left operand only.