### PR TITLE
refactor: remove unimplemented #pragma sync and #pragma nosync handlers

### DIFF
--- a/src/pdtoken.cpp
+++ b/src/pdtoken.cpp
@@ -1093,40 +1093,7 @@ Pdtoken::process_pragma()
 		eat_to_eol();
 		return;
 	}
-	if (t.get_val() == "sync") {
-		t.getnext_nospc<Fchar>();
-		if (t.get_code() != STRING_LITERAL) {
-			/*
-			 * @error
-			 * The
-			 * <code>#pragma sync</code>
-			 * CScout-specific directive was not followed by a
-			 * string
-			 */
-			Error::error(E_ERR, "#pragma sync: string expected");
-			eat_to_eol();
-			return;
-		}
-		string fname = t.get_val();
-		t.getnext_nospc<Fchar>();
-		if (t.get_code() != PP_NUMBER) {
-			/*
-			 * @error
-			 * The filename of the
-			 * <code>#pragma sync</code>
-			 * CScout-specific directive was not followed by an
-			 * integer
-			 */
-			Error::error(E_ERR, "#pragma sync: integer expected");
-			eat_to_eol();
-			return;
-		}
-		char *endptr;
-		(void)strtoul(t.get_val().c_str(), &endptr, 0);
-		// XXX now do the work
-	} else if (t.get_val() == "nosync") {
-		// XXX now do the work
-	} else if (t.get_val() == "once") {
+	if (t.get_val() == "once") {
 		// Mark the file for skipping next time it is included.
 		Fileid fid(Fchar::get_fileid());
 		if (DP()) cout << "Pragma once on " << fid.get_path() << "\n";

--- a/src/test/out/mkerr
+++ b/src/test/out/mkerr
@@ -38,15 +38,7 @@ string.<p><li> <code>#pragma set_dp: line number expected</code><br>
 The file name in the
 <code>#pragma set_dp</code>
 CScout-specific directive was not followed by a
-line number.<p><li> <code>#pragma sync: integer expected</code><br>
-The filename of the
-<code>#pragma sync</code>
-CScout-specific directive was not followed by an
-integer.<p><li> <code>#pragma sync: string expected</code><br>
-The
-<code>#pragma sync</code>
-CScout-specific directive was not followed by a
-string.<p><li> <code>% not followed by yacc keyword</code><br>
+line number.<p><li> <code>% not followed by yacc keyword</code><br>
 In the definitions section of a yacc file the
 % symbol was not followed by a legal yacc keyword.<p><li> <code>%union does not have a member  ...</code><br>
 The member used in a $&lt;name&gt;X yacc construct


### PR DESCRIPTION
### Description

Removes the `#pragma sync` and `#pragma nosync` handlers in `Pdtoken::process_pragma()`. Both branches have carried `// XXX now do the work` comments since July 2003 (commits 2cdfb395 and 4ab8c1bf) and were never implemented:

- The `sync` branch parsed its string argument and integer argument with `strtoul`, then discarded both values (the result was cast to `void`).
- The `nosync` branch was an empty stub.

Neither directive is referenced anywhere else in the source tree, neither appears in `doc/pragma.xml`, and no test exercises them. After removal, `#pragma sync` and `#pragma nosync` fall through to the existing `eat_to_eol()` at the end of `process_pragma()`, which is the same silent-ignore path used for any unrecognized pragma.

### Changes

- `src/pdtoken.cpp`: removed the two dead `else if` branches and their `@error` documentation comments.
- `src/test/out/mkerr`: removed the two corresponding entries from the expected output of the `mkerr.pl` test. Regenerated baseline matches `perl mkerr.pl` output exactly.

### Testing

- `perl -c mkerr.pl` compiles cleanly under `use strict; use warnings;`.
- `diff <(perl mkerr.pl) src/test/out/mkerr` produces no differences.
- CI passes on both Ubuntu and macOS.