### PR TITLE
fix: handle fopen failure in call graph output paths

### DIFF
--- a/src/cscout.cpp
+++ b/src/cscout.cpp
@@ -2401,6 +2401,10 @@ graph_txt_page(FILE *fo, void (*graph_fun)(GraphDisplay *))
 	char *outfile;
 	if (swill_getargs("i(output)s(outfile)", &output, &outfile) && output && strlen(outfile)) {
 		FILE *ofile = fopen(outfile, "w+");
+		if (ofile == NULL) {
+			html_perror(fo, "Unable to open " + string(outfile) + " for writing");
+			return 0;
+		}
 		GDTxt gdout(ofile);
 		graph_fun(&gdout);
 		fclose(ofile);
@@ -2505,6 +2509,10 @@ produce_call_graphs(const vector <string> &call_graphs)
 		}
 
 		FILE *target = fopen(split_base_and_opts[0].c_str() , "w+");
+		if (target == NULL) {
+			perror(split_base_and_opts[0].c_str());
+			continue;
+		}
 		string base = split_base_and_opts[0];
 		GDTxt gd(target);
 		// Disable swill


### PR DESCRIPTION
### Problem

Two `fopen` calls in `cscout.cpp` do not check the return value. When `fopen` fails (destination directory does not exist, permission denied, disk full, etc.), the resulting NULL `FILE *` is passed to the `GDTxt` constructor and later to `fclose`. Writing to or closing a NULL FILE pointer is undefined behavior; on glibc 2.39 it segfaults.

Two distinct entry points are affected:

1. `graph_txt_page` (web handler, line 2403). An HTTP request like `cgraph.txt?output=1&outfile=/tmp/readonly/foo` crashes the CScout web server.
2. `produce_call_graphs` (CLI handler, line 2507), invoked via the `-R` command-line option. For example:

```
$ cscout -R '/tmp/readonly/cgraph.txt?all=1' awk.cs
...
Producing call graphs for: /tmp/readonly/cgraph.txt?all=1
Segmentation fault (core dumped)
$ echo $?
139
```

This pattern of checking `fopen` for NULL is already used elsewhere in the same file (line 3556, `-l` logfile handler) and in `src/gdisplay.cpp`, `src/md5.cpp`.

### Fix

- `graph_txt_page`: on `fopen` failure, call `html_perror` with the attempted path and return, which serves an HTTP error page containing `strerror(errno)`. This matches the existing error reporting pattern used by `GDDotImage` in `src/gdisplay.cpp`.
- `produce_call_graphs`: on `fopen` failure, call `perror` with the attempted path and `continue` to the next URL in the list, matching the existing `"is not a valid url"` fallthrough behavior a few lines above.

### Testing

Verified locally on Ubuntu 24.04 (glibc 2.39):

```
# Before the patch, with an unwritable output path:
$ cscout -R '/tmp/readonly/cgraph.txt?all=1' awk.cs; echo $?
...
Producing call graphs for: /tmp/readonly/cgraph.txt?all=1
139    # SIGSEGV

# After the patch:
$ cscout -R '/tmp/readonly/cgraph.txt?all=1' awk.cs; echo $?
...
Producing call graphs for: /tmp/readonly/cgraph.txt?all=1
/tmp/readonly/cgraph.txt: Permission denied
0
```