### PR TITLE
Guard against empty token sequence in gather_defined_operator (macro fix)

### DIFF
--- a/src/macro.cpp
+++ b/src/macro.cpp
@@ -313,10 +313,12 @@ gather_defined_operator(PtokenSequence& tokens)
 	PtokenSequence r;
 
 	// Skip leading space
-	while (tokens.front().get_code() == SPACE) {
+	while (!tokens.empty() && tokens.front().get_code() == SPACE) {
 		r.push_back(tokens.front());
 		tokens.pop_front();
 	}
+	if (tokens.empty())
+		goto error;
 	switch (tokens.front().get_code()) {
 	case IDENTIFIER:
 		// defined X form
@@ -328,20 +330,20 @@ gather_defined_operator(PtokenSequence& tokens)
 		r.push_back(tokens.front());
 		tokens.pop_front();
 		// Skip space
-		while (tokens.front().get_code() == SPACE) {
+		while (!tokens.empty() && tokens.front().get_code() == SPACE) {
 			r.push_back(tokens.front());
 			tokens.pop_front();
 		}
-		if (tokens.front().get_code() != IDENTIFIER)
+		if (tokens.empty() || tokens.front().get_code() != IDENTIFIER)
 			goto error;
 		r.push_back(tokens.front());
 		tokens.pop_front();
 		// Skip space
-		while (tokens.front().get_code() == SPACE) {
+		while (!tokens.empty() && tokens.front().get_code() == SPACE) {
 			r.push_back(tokens.front());
 			tokens.pop_front();
 		}
-		if (tokens.front().get_code() != ')')
+		if (tokens.empty() || tokens.front().get_code() != ')')
 			goto error;
 		r.push_back(tokens.front());
 		tokens.pop_front();


### PR DESCRIPTION
## Problem

`gather_defined_operator()` calls `tokens.front()` without checking if the deque is empty first. A malformed `defined` expression, e.g. a bare `defined` at the end of a macro argument list triggers undefined behaviour rather than a clean diagnostic.

## Fix

Add `!tokens.empty()` guards before every `tokens.front()` access in `gather_defined_operator()`. Malformed input now falls through to the existing `error:` label and emits a proper error message.

## Test plan
- [ ] `make check` passes with no regressions
- [ ] Manually test with `#if defined` (no operand) expect an error, not a crash