### PR TITLE
Prevent line concatenation when included file lacks trailing newline 

### DIFF
--- a/src/fchar.cpp
+++ b/src/fchar.cpp
@@ -183,7 +183,7 @@ Fchar::getnext()
 		simple_getnext();
 
 		static int oval;
-		if (val == EOF && oval != '\n')
+		if (val == EOF && oval != '\n') {
 			/*
 			 * @error
 			 * An included file does not end with a newline
@@ -192,6 +192,23 @@ Fchar::getnext()
 			 * command is unspecified.
 			 */
 			Error::error(E_WARN, "Included file does not end with a newline.");
+			/*
+			 * For included files (context stack non-empty), synthesize a
+			 * newline so the next file's first line is not concatenated
+			 * with this file's last line (fixes #48).
+			 * The actual EOF cleanup runs on the following getnext() call
+			 * when the stream returns EOF again with oval == '\n'.
+			 */
+			if (!cs.empty() && cs.size() != stack_lock_size) {
+				Filedetails::set_line_processed(fi, !Pdtoken::skipping());
+				line_number++;
+				val = '\n';
+				oval = '\n';
+				if (DP())
+					cout << "getnext returns synthetic newline for missing EOL\n";
+				return;
+			}
+		}
 		if (val != EOF)
 			oval = val;
 		if (val == EOF) {


### PR DESCRIPTION
## Summary
- Fixes #48: when an included file lacks a trailing newline, `getnext()` now synthesizes a `'\n'` before popping the file context stack
- Prevents the first token of the following file from being incorrectly concatenated onto the last line of the incomplete file
- Top-level files (empty context stack) are unaffected

## Test plan
- [ ] Build and run existing test suite (`make check`)
- [ ] Verify no regression in line number counting for normally-terminated files
- [ ] Manually test with an included file that has no trailing newline