### PR TITLE
Fix is_unused in dbtoken to use Eclass::is_unused()

### DIFF
--- a/src/dbtoken.cpp
+++ b/src/dbtoken.cpp
@@ -518,12 +518,7 @@ Dbtoken::dump_id(ostream &of, Eclass *e, const string &name)
 	     e->get_attribute(is_cfunction) << ',' <<
 	     e->get_attribute(is_cscope) << ',' <<
 	     e->get_attribute(is_lscope) << ',' <<
-	     /*
-	      * Simplified version of is_unused.
-	      * This can be improved by saving and merging is_declared_unused
-	      * attribute and the identical files table.
-	      */
-	     (e->get_size() == 1) <<
+	     e->is_unused() <<
 	     '\n';
 }
 


### PR DESCRIPTION
## Problem
In `dbtoken.cpp`, the `UNUSED` field in the `Ids` SQL table was computed using a simplified approximation:

```cpp
(e->get_size() == 1)
```

The code itself contained a comment acknowledging this:
> "Simplified version of is_unused. This can be improved by saving and
> merging is_declared_unused attribute and the identical files table."

## Fix
Replace the approximation with the already-implemented `Eclass::is_unused()` method, which correctly handles:
- Identifiers declared with `__attribute__((unused))` — via `is_declared_unused`
- Identifiers whose occurrences all come from identical header files — via `get_identical_files()`

## Consistency
`Eclass::is_unused()` was already being used correctly in:
- `workdb.cpp` line 182
- `idquery.cpp` lines 253, 264, 275, 286
- `cscout.cpp` lines 381, 1463

`dbtoken.cpp` was the only place still using the old approximation.

## When this matters
The fix produces different (correct) results in two real-world scenarios:

1. An identifier marked `__attribute__((unused))` appears in a header included in multiple translation units. Old code: `get_size() > 1` → UNUSED=0 (wrong). New code: `is_declared_unused` is set → correctly not flagged as unintentionally unused.

2. An identifier appears only in identical duplicate header files included across many translation units. Old code: `get_size() > 1` → UNUSED=0 (wrong). New code: `get_identical_files()` detects all occurrences are from identical files → UNUSED=1 (correct).

## Verification
All 255 tests pass.