### PR TITLE
Moving general utilities out of cscout.cpp

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -37,7 +37,7 @@ OBJBASE=eclass.o fchar.o filedetails.o fileid.o pdtoken.o pltoken.o debug.o \
   error.o fdep.o fcall.o call.o idquery.o query.o funquery.o \
   logo.o workdb.o obfuscate.o sql.o md5.o os.o pager.o \
   option.o filequery.o mcall.o filemetrics.o funmetrics.o ctconst.o \
-  dirbrowse.o html.o fileutils.o gdisplay.o globobj.o ctag.o timer.o \
+  dirbrowse.o html.o fileutils.o util.o gdisplay.o globobj.o ctag.o timer.o \
   static_init.o initializer.o
 
 # monitor.o

--- a/src/cscout.cpp
+++ b/src/cscout.cpp
@@ -95,6 +95,7 @@ using namespace picoQL;
 #include "sql.h"
 #include "workdb.h"
 #include "obfuscate.h"
+#include "util.h"
 
 #define ids Identifier::ids
 
@@ -2478,20 +2479,6 @@ graph_pdf_page(FILE *fo, void (*graph_fun)(GraphDisplay *))
 }
 
 
-// Split a string by delimiter
-vector<string> split_by_delimiter(string &s, char delim) {
-	string buf;                 // Have a buffer string
-	stringstream ss(s);       // Insert the string into a stream
-
-	vector<string> tokens; // Create vector to hold our words
-
-	while (getline(ss, buf, delim))
-		tokens.push_back(buf);
-
-	return tokens;
-}
-
-
 // Produce call graphs with -R option
 static void
 produce_call_graphs(const vector <string> &call_graphs)
@@ -2610,47 +2597,6 @@ set_project_page(FILE *fo, void *p)
 	}
 	index_page(fo, p);
 	return 0;
-}
-
-// Return version information
-static string
-version_info(bool html)
-{
-	ostringstream v;
-
-	string end = html ? "<br />" : "\n";
-	string fold = html ? " " : "\n";
-
-	v << "CScout version " <<
-	Version::get_revision() << " - " <<
-	Version::get_date() << end << end <<
-	// 80 column terminal width---------------------------------------------------
-	"(c) Copyright 2003-" << ((char *)__DATE__ + string(__DATE__).length() - 4) <<
-				 // Current year
-	" Diomidis Spinelllis." << end <<
-	end <<
-	// C grammar
-	"Portions Copyright (c) 1989, 1990 James A. Roskind." << end <<
-	// MD-5
-	"Portions derived from the RSA Data Security, Inc. MD5 Message-Digest Algorithm." << end <<
-
-	"Includes the SWILL (Simple Web Interface Link Library) library written by David" << fold <<
-	"Beazley and Sotiria Lampoudi.  Copyright (c) 1998-2002 University of Chicago." << fold <<
-	"SWILL is distributed under the terms of the GNU Lesser General Public License" << fold <<
-	"version 2.1 available " <<
-	(html ? "<a href=\"http://www.gnu.org/licenses/lgpl-2.1.html\">online</a>." : "online at http://www.gnu.org/licenses/lgpl-2.1.html.") << end <<
-
-	end <<
-	"CScout is distributed as open source software under the GNU" << fold <<
-	"General Public License, available in the CScout documentation and ";
-	if (html)
-		v << "<a href=\"http://www.gnu.org/licenses/\">online</a>.";
-	else
-		v << "online at" << end <<
-		"http://www.gnu.org/licenses/." << end;
-	v << "Other licensing options and professional support are available"
-		" on request." << end;
-	return v.str();
 }
 
 // Display information about CScout

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,0 +1,86 @@
+/*
+ * (C) Copyright 2008-2026 Diomidis Spinellis
+ *
+ * This file is part of CScout.
+ *
+ * CScout is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CScout is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CScout.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * General utility functions.
+ *
+ */
+
+
+#include <string>
+#include <vector>
+#include <sstream>
+
+#include "version.h"
+#include "util.h"
+
+// Split a string by delimiter 
+std::vector<std::string>
+split_by_delimiter(std::string &s, char delim) 
+{
+    std::string buf;                     // Have a buffer string
+    std::stringstream ss(s);            // Insert the string into a stream
+    std::vector<std::string> tokens;    // Create vector to hold our words
+
+    while (getline(ss, buf, delim)) 
+        tokens.push_back(buf);
+    
+
+    return tokens;
+}
+
+// Return version information
+std::string
+version_info(bool html)
+{
+	std::ostringstream v;
+
+	string end = html ? "<br />" : "\n";
+	string fold = html ? " " : "\n";
+
+	v << "CScout version " <<
+	Version::get_revision() << " - " <<
+	Version::get_date() << end << end <<
+	// 80 column terminal width---------------------------------------------------
+	"(c) Copyright 2003-" << ((char *)__DATE__ + string(__DATE__).length() - 4) <<
+				 // Current year
+	" Diomidis Spinelllis." << end <<
+	end <<
+	// C grammar
+	"Portions Copyright (c) 1989, 1990 James A. Roskind." << end <<
+	// MD-5
+	"Portions derived from the RSA Data Security, Inc. MD5 Message-Digest Algorithm." << end <<
+
+	"Includes the SWILL (Simple Web Interface Link Library) library written by David" << fold <<
+	"Beazley and Sotiria Lampoudi.  Copyright (c) 1998-2002 University of Chicago." << fold <<
+	"SWILL is distributed under the terms of the GNU Lesser General Public License" << fold <<
+	"version 2.1 available " <<
+	(html ? "<a href=\"http://www.gnu.org/licenses/lgpl-2.1.html\">online</a>." : "online at http://www.gnu.org/licenses/lgpl-2.1.html.") << end <<
+
+	end <<
+	"CScout is distributed as open source software under the GNU" << fold <<
+	"General Public License, available in the CScout documentation and ";
+	if (html)
+		v << "<a href=\"http://www.gnu.org/licenses/\">online</a>.";
+	else
+		v << "online at" << end <<
+		"http://www.gnu.org/licenses/." << end;
+	v << "Other licensing options and professional support are available"
+		" on request." << end;
+	return v.str();
+}

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,33 @@
+/*
+ * (C) Copyright 2008-2026 Diomidis Spinellis
+ *
+ * This file is part of CScout.
+ *
+ * CScout is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CScout is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CScout.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * General utility functions.
+ *
+ */
+
+#ifndef UTIL_H
+#define UTIL_H
+
+#include <string>
+#include <vector>
+
+std::vector<std::string> split_by_delimiter(std::string &s, char delim);
+std::string version_info(bool html);
+
+#endif  /* UTIL_H */


### PR DESCRIPTION
## Summary

`split_by_delimiter` and` version_info` were defined in `cscout.cpp`. However, neither belongs to the analysis engine nor the HTML interface. This PR moves them `util.h` and `util.cpp`, making `cscout.cpp` smaller and more focused.

## Changes 

Added `src/util.h` with declarations
Added `src/utilcpp` with function definitions
Removed both fucntions from `cscout.cpp`
Added `util.o` to `src/Makefile`

## Testing

All existing tests pass