### PR TITLE
Group invocation options into CscoutOptions

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -37,7 +37,7 @@ OBJBASE=eclass.o fchar.o filedetails.o fileid.o pdtoken.o pltoken.o debug.o \
   error.o fdep.o fcall.o call.o idquery.o query.o funquery.o \
   logo.o workdb.o obfuscate.o sql.o md5.o os.o pager.o \
   option.o filequery.o mcall.o filemetrics.o funmetrics.o ctconst.o \
-  dirbrowse.o html.o fileutils.o util.o gdisplay.o globobj.o ctag.o timer.o \
+  dirbrowse.o html.o fileutils.o util.o options.o gdisplay.o globobj.o ctag.o timer.o \
   static_init.o initializer.o
 
 # monitor.o

--- a/src/cscout.cpp
+++ b/src/cscout.cpp
@@ -97,6 +97,8 @@ using namespace picoQL;
 #include "obfuscate.h"
 #include "progress.h"
 #include "util.h"
+#include "options.h"
+CscoutOptions opts;
 
 #define ids Identifier::ids
 
@@ -110,18 +112,6 @@ using namespace picoQL;
 	} while (0)
 
 
-// Global command-line options
-static enum e_process {
-	pm_unspecified,			// Default (web front-end) must be 0
-	pm_preprocess,			// Preprocess-only (-E)
-	pm_compile,			// Compile-only (-c)
-	pm_report,			// Generate a warning report
-	pm_database,
-	pm_obfuscation,
-	pm_call_graph
-} process_mode;
-static int portno = 8081;		// Port number (-p n)
-static string db_engine;		// Create SQL output for a specific db_iface
 
 // Workspace modification state
 static enum e_modification_state {
@@ -144,12 +134,8 @@ static bool browse_only = false;
 // Maximum number of nodes and edges allowed to browsing-only clients
 #define MAX_BROWSING_GRAPH_ELEMENTS 1000
 
-static bool quiet = false;           //added a global variable for quiet 
-
 static CompiledRE sfile_re;			// Saved files replacement location RE
 
-// Identifiers to monitor (-m parameter)
-static IdQuery monitor;
 
 static vector <Fileid> files;
 
@@ -281,7 +267,7 @@ file_analyze(Fileid fi)
 	Call *cfun = NULL;			// Current function
 	stack <Call *> fun_nesting;
 
-	if (!quiet)
+	if (!opts.is_quiet())
 	    cerr << "Post-processing " << fname << endl;
 	in.open(fname.c_str(), ios::binary);
 	if (in.fail()) {
@@ -334,9 +320,9 @@ file_analyze(Fileid fi)
 		    (ei = ti.find_ec()) != ti.end_ec()) {
 			Eclass *ec = (*ei).second;
 			// Remove identifiers we are not supposed to monitor
-			if (monitor.is_valid()) {
+			if (opts.monitor.is_valid()) {
 				IdPropElem ec_id(ec, Identifier());
-				if (!monitor.eval(ec_id)) {
+				if (!opts.monitor.eval(ec_id)) {
 					ec->remove_from_tokid_map();
 					delete ec;
 					continue;
@@ -845,7 +831,7 @@ file_refactor(FILE *of, Fileid fid)
 	fifstream in;
 	ofstream out;
 
-	if (!quiet)
+	if (!opts.is_quiet())
 	    cerr << "Processing file " << fid.get_path() << endl;
 
 	if (RefFunCall::store.size())
@@ -1306,7 +1292,7 @@ xiquery_page(FILE *of,  void *)
 	}
 
 	html_head(of, "xiquery", (qname && *qname) ? qname : "Identifier Query Results");
-	if (!quiet)
+	if (!opts.is_quiet())
 	    cerr << "Evaluating identifier query" << endl;
 	for (IdProp::iterator i = ids.begin(); i != ids.end(); i++) {
 		progress(i, ids);
@@ -1322,7 +1308,7 @@ xiquery_page(FILE *of,  void *)
 			funs.insert(ecfuns.begin(), ecfuns.end());
 		}
 	}
-	if (!quiet)
+	if (!opts.is_quiet())
 	    cerr << endl;
 	if (q_id) {
 		fputs("<h2>Matching Identifiers</h2>\n", of);
@@ -1362,7 +1348,7 @@ xfunquery_page(FILE *of,  void *)
 		return 0;
 
 	html_head(of, "xfunquery", (qname && *qname) ? qname : "Function Query Results");
-	if (!quiet)
+	if (!opts.is_quiet())
 	    cerr << "Evaluating function query" << endl;
 	for (Call::const_fmap_iterator_type i = Call::fbegin(); i != Call::fend(); i++) {
 		progress(i, Call::functions());
@@ -1373,7 +1359,7 @@ xfunquery_page(FILE *of,  void *)
 		if (q_file)
 			sorted_files.insert(i->second->get_fileid());
 	}
-	if (!quiet)
+	if (!opts.is_quiet())
 	    cerr << endl;
 	if (q_id) {
 		fputs("<h2>Matching Functions</h2>\n", of);
@@ -2396,7 +2382,7 @@ graph_txt_page(FILE *fo, void (*graph_fun)(GraphDisplay *))
 		fclose(ofile);
 	}
 
-	if (process_mode != pm_call_graph) {
+	if (opts.process_mode != CscoutOptions::pm_call_graph) {
 		GDTxt gd(fo);
 		graph_fun(&gd);
 	}
@@ -2943,7 +2929,7 @@ replacements_page(FILE *of, void *)
 	prohibit_remote_access(of);
 	html_head(of, "replacements", "Identifier Replacements");
 	
-	if (!quiet)
+	if (!opts.is_quiet())
 	    cerr << "Creating identifier list" << endl;
 	fputs("<p><form action=\"xreplacements.html\" method=\"get\">\n"
 		"<table><tr><th>Identifier</th><th>Replacement</th><th>Active</th></tr>\n"
@@ -2961,7 +2947,7 @@ replacements_page(FILE *of, void *)
 				(void *)&(i->second), i->second.get_active() ? "checked" : "");
 		}
 	}
-	if (!quiet)
+	if (!opts.is_quiet())
 	    cerr << endl;
 	fputs("</table><p><INPUT TYPE=\"submit\" name=\"repl\" value=\"OK\">\n", of);
 	html_tail(of);
@@ -2975,7 +2961,7 @@ xreplacements_page(FILE *of,  void *p)
 	prohibit_browsers(of);
 	prohibit_remote_access(of);
 
-	if (!quiet)
+	if (!opts.is_quiet())
 	    cerr << "Creating identifier list" << endl;
 
 	for (IdProp::iterator i = ids.begin(); i != ids.end(); i++) {
@@ -2993,7 +2979,7 @@ xreplacements_page(FILE *of,  void *p)
 			i->second.set_active(!!swill_getvar(varname));
 		}
 	}
-	if (!quiet)
+	if (!opts.is_quiet())
 	    cerr << endl;
 	index_page(of, p);
 	return 0;
@@ -3070,7 +3056,7 @@ write_quit_page(FILE *of, void *exit)
 
 	// Determine files we need to process
 	IFSet process;
-	if (!quiet)
+	if (!opts.is_quiet())
 	    cerr << "Examining identifiers for renaming" << endl;
 	for (IdProp::iterator i = ids.begin(); i != ids.end(); i++) {
 		progress(i, ids);
@@ -3080,13 +3066,13 @@ write_quit_page(FILE *of, void *exit)
 			process.insert(ifiles.begin(), ifiles.end());
 		}
 	}
-	if (!quiet)
+	if (!opts.is_quiet())
 	    cerr << endl;
 
 	// Check for identifier clashes
 	Token::found_clashes = false;
 	if (Option::refactor_check_clashes->get() && process.size()) {
-		if (!quiet)
+		if (!opts.is_quiet())
 		    cerr << "Checking rename refactorings for name clashes." << endl;
 		Token::check_clashes = true;
 		// Reparse everything
@@ -3105,7 +3091,7 @@ write_quit_page(FILE *of, void *exit)
 		return 0;
 	}
 
-	if (!quiet) 
+	if (!opts.is_quiet()) 
 	    cerr << "Examining function calls for refactoring" << endl;
 	for (RefFunCall::store_type::iterator i = RefFunCall::store.begin(); i != RefFunCall::store.end(); i++) {
 		progress(i, RefFunCall::store);
@@ -3115,11 +3101,11 @@ write_quit_page(FILE *of, void *exit)
 		IFSet ifiles = e->sorted_files();
 		process.insert(ifiles.begin(), ifiles.end());
 	}
-	if (!quiet)
+	if (!opts.is_quiet())
 	    cerr << endl;
 
 	// Now do the replacements
-	if (!quiet)
+	if (!opts.is_quiet())
 	    cerr << "Processing files" << endl;
 	for (IFSet::const_iterator i = process.begin(); i != process.end(); i++)
 		file_refactor(of, *i);
@@ -3283,74 +3269,7 @@ warning_report()
 	}
 }
 
-// Report usage information and exit
-static void
-usage(char *fname)
-{
-	cerr << "usage: " << fname <<
-		" ["
-#ifndef WIN32
-		"-b|"	// browse-only
-#endif
-		"-C|-c|-d D|-d H|-E RE|-o|-M files|"
-		"-q|-R URL|-r|-S db|-s db|-v] "
-		"[-l file] "
 
-#ifdef PICO_QL
-#define PICO_QL_OPTIONS "q"
-		"-q|"
-#else
-#define PICO_QL_OPTIONS ""
-#endif
-
-		"[-P RE] [-p port] [-m spec] [-t table ...] file\n"
-#ifndef WIN32
-		"\t-b\tRun in multiuser browse-only mode\n"
-#endif
-		"\t-C\tCreate a ctags(1)-compatible tags file\n"
-		"\t-c\tProcess the file and exit\n"
-		"\t-R URL\tOutput the call graphs specified by the URLs exit\n"
-		"\t-d D\tOutput the #defines being processed\n"
-		"\t-d H\tOutput the names of included files being processed\n"
-		"\t-E RE\tOutput preprocessed results and exit\n"
-		"\t\t(Will process file(s) matched by the regular expression)\n"
-		"\t-l file\tSpecify access log file\n"
-		"\t-M files\tMerge specified EC files\n"
-		"\t-m spec\tSpecify identifiers to monitor (unsound)\n"
-		"\t-o\tCreate obfuscated versions of the processed files\n"
-		"\t-P RE\tProcess only file(s) matched by the regular expression\n"
-		"\t-p port\tSpecify TCP port for serving the CScout web pages\n"
-		"\t\t(the port number must be in the range 1024-32767)\n"
-#ifdef PICO_QL
-		"\t-q\tProvide a PiCO_QL query interface\n"
-#else
-		"\t-q\tSuppress progress messages on standard error\n"
-#endif
-		"\t-r\tGenerate an identifier and include file warning report\n"
-		"\t-S db\tGenerate the SQL schema for the specified RDBMS\n"
-		"\t-s db\tGenerate SQL output for the specified RDBMS\n"
-		"\t-t table\tEnable population of the specified RDBMS table\n"
-		"\t\t(All enabled by default. Option can be provided multiple times)\n"
-		"\t-v\tDisplay version and copyright information and exit\n"
-		"\t-3\tEnable the handling of trigraph characters\n"
-		;
-	exit(1);
-}
-
-
-// Return a compiled RE for the string s, verifying its correctness
-static CompiledRE
-verified_compiled_re(const char *s)
-{
-	CompiledRE pre(s, REG_EXTENDED | REG_NOSUB);
-
-	if (!pre.isCorrect()) {
-		cerr << "Filename regular expression error:" <<
-			pre.getError() << '\n';
-		exit(1);
-	}
-	return pre;
-}
 
 /*
  * Read files with tokens classes and identifier attributes
@@ -3411,148 +3330,29 @@ int
 main(int argc, char *argv[])
 {
 	Pdtoken t;
-	int c;
-	CompiledRE pre;
-#ifdef PICO_QL
-	bool pico_ql = false;
-#endif
-
-	vector<string> call_graphs;
 	Debug::db_read();
 
-	while ((c = getopt(argc, argv, "3bCcd:rvE:P:p:Mm:l:oR:S:s:t:q" PICO_QL_OPTIONS)) != EOF)  //added q for quiet
-		switch (c) {
-		case '3':
-			Fchar::enable_trigraphs();
-			break;
-		case 'E':
-			if (!optarg || process_mode)
-				usage(argv[0]);
-			// Preprocess the specified file
-			Pdtoken::set_preprocessed_output(verified_compiled_re(optarg));
-			process_mode = pm_preprocess;
-			break;
-		case 'C':
-			CTag::enable();
-			break;
-		#ifdef PICO_QL
-		case 'q':
-			pico_ql = true;
-			/* FALLTHROUGH */
-		#endif
-		case 'c':
-			if (process_mode)
-				usage(argv[0]);
-			process_mode = pm_compile;
-			break;
-		case 'd':
-			if (!optarg)
-				usage(argv[0]);
-			switch (*optarg) {
-			case 'D':	// Similar to gcc -dD
-				Pdtoken::set_output_defines();
-				break;
-			case 'H':	// Similar to gcc -H
-				Fchar::set_output_headers();
-				break;
-			default:
-				usage(argv[0]);
-			}
-			break;
-		case 'p':
-			if (!optarg)
-				usage(argv[0]);
-			portno = atoi(optarg);
-			if (portno < 1024 || portno > 32767)
-				usage(argv[0]);
-			break;
-		case 'M':
-			merge_tokens(argv);
-			break;
-		case 'm':
-			if (!optarg)
-				usage(argv[0]);
-			monitor = IdQuery(optarg);
-			break;
-		case 'r':
-			if (process_mode)
-				usage(argv[0]);
-			process_mode = pm_report;
-			break;
-		case 'v':
-			cout << version_info(false);
-			exit(0);
-		case 'b':
-			browse_only = true;
-			break;
-		case 'q':
-			quiet = true;
-			break;
-		case 'l':
-			if (!optarg)
-				usage(argv[0]);
-			FILE *logfile;
-			if ((logfile = fopen(optarg, "a")) == NULL) {
-				perror(optarg);
-				exit(1);
-			}
-			swill_log(logfile);
-			break;
-		case 'o':
-			if (process_mode)
-				usage(argv[0]);
-			process_mode = pm_obfuscation;
-			break;
-		case 'P':
-			if (!optarg)
-				usage(argv[0]);
-			// Process the specified file(s)
-			Pdtoken::set_processed_files(verified_compiled_re(optarg));
-			break;
-		case 'S':
-			if (process_mode)
-				usage(argv[0]);
-			if (!optarg)
-				usage(argv[0]);
-			db_engine = optarg;
-			if (!Sql::setEngine(optarg))
-				return 1;
-			workdb_schema(Sql::getInterface(), cout);
-			exit(0);
-		case 's':
-			if (process_mode)
-				usage(argv[0]);
-			if (!optarg)
-				usage(argv[0]);
-			process_mode = pm_database;
-			db_engine = optarg;
-			break;
-		case 't':
-			if (!optarg)
-				usage(argv[0]);
-			table_enable(optarg);
-			break;
-		case 'R':
-			if (!optarg)
-				usage(argv[0]);
-			process_mode = pm_call_graph;
-			call_graphs.push_back(string(optarg));
-			break;
-		case '?':
-			usage(argv[0]);
-		}
+	opts.parse_args(argc, argv);
 
+	if (opts.do_merge)
+		merge_tokens(argv);
+
+	if (!opts.log_file.empty()) {
+		FILE *logfile;
+		if ((logfile = fopen(opts.log_file.c_str(), "a")) == NULL) {
+			perror(opts.log_file.c_str());
+			exit(1);
+		}
+		swill_log(logfile);
+	}
 
 	// We require exactly one argument
 	if (argv[optind] == NULL || argv[optind + 1] != NULL)
 		usage(argv[0]);
 
-	if (process_mode != pm_compile
-	    && process_mode != pm_database
-	    && process_mode != pm_obfuscation
-	    && process_mode != pm_preprocess) {
-		if (!swill_init(portno)) {
-			cerr << "Couldn't initialize our web server on port " << portno << endl;
+	if (opts.is_web_server_mode()) {
+		if (!swill_init(opts.portno)) {
+			cerr << "Couldn't initialize our web server on port " << opts.portno << endl;
 			exit(1);
 		}
 
@@ -3561,8 +3361,8 @@ main(int argc, char *argv[])
 		parse_acl();
 	}
 
-	if (process_mode == pm_database) {
-		if (!Sql::setEngine(db_engine))
+	if (opts.process_mode == CscoutOptions::pm_database) {
+		if (!Sql::setEngine(opts.db_engine))
 			return 1;
 		cout << Sql::getInterface()->begin_commands();
 		workdb_schema(Sql::getInterface(), cout);
@@ -3582,14 +3382,14 @@ main(int argc, char *argv[])
 	while (t.get_code() != EOF);
 	Error::set_parsing(false);
 
-	if (process_mode == pm_preprocess)
+	if (opts.process_mode == CscoutOptions::pm_preprocess)
 		return 0;
 
 	input_file_id = Fileid(argv[optind]);
 
 	Filedetails::unify_identical_files();
 
-	if (process_mode == pm_obfuscation)
+	if (opts.process_mode == CscoutOptions::pm_obfuscation)
 		return obfuscate();
 
 	// Pass 2: Create web pages
@@ -3597,7 +3397,7 @@ main(int argc, char *argv[])
 
 
 
-	if (process_mode != pm_compile) {
+	if (opts.process_mode != CscoutOptions::pm_compile) {
 		swill_handle("sproject.html", select_project_page, 0);
 		swill_handle("replacements.html", replacements_page, 0);
 		swill_handle("xreplacements.html", xreplacements_page, NULL);
@@ -3629,7 +3429,7 @@ main(int argc, char *argv[])
 	GlobObj::set_file_dependencies();
 
 	// Set xfile and  metrics for each identifier
-	if (!quiet)
+	if (!opts.is_quiet())
 	    cerr << "Processing identifiers" << endl;
 	for (IdProp::iterator i = ids.begin(); i != ids.end(); i++) {
 		progress(i, ids);
@@ -3639,13 +3439,13 @@ main(int argc, char *argv[])
 		// Update metrics
 		id_msum.add_unique_id(e);
 	}
-	if (!quiet)
+	if (!opts.is_quiet())
 	    cerr << endl;
 
 	if (DP())
 		cout << "Size " << file_msum.get_pre_cpp_total(Metrics::em_nchar) << endl;
 
-	if (process_mode == pm_database) {
+	if (opts.process_mode == CscoutOptions::pm_database) {
 		workdb_rest(Sql::getInterface(), cout);
 		Call::dumpSql(Sql::getInterface(), cout);
 		cout << Sql::getInterface()->end_commands();
@@ -3660,7 +3460,7 @@ main(int argc, char *argv[])
 		return 0;
 	}
 
-	if (process_mode != pm_compile) {
+	if (opts.process_mode != CscoutOptions::pm_compile) {
 		swill_handle("src.html", source_page, NULL);
 		swill_handle("qsrc.html", query_source_page, NULL);
 		swill_handle("fedit.html", fedit_page, NULL);
@@ -3708,40 +3508,40 @@ main(int argc, char *argv[])
 	}
 
 	CTag::save();
-	if (process_mode == pm_report) {
+	if (opts.process_mode == CscoutOptions::pm_report) {
 		if (!must_exit)
 			warning_report();
 		return (0);
 	}
 
 #ifdef PICO_QL
-	if (pico_ql) {
+	if (opts.pico_ql) {
 		pico_ql_register(&files, "files");
 		pico_ql_register(&Identifier::ids, "ids");
 		pico_ql_register(&Tokid::tm, "tm");
 		pico_ql_register(&Call::functions(), "fun_map");
-		while (pico_ql_serve(portno))
+		while (pico_ql_serve(opts.portno))
 			;
 		return (0);
 	}
 #endif
 
-	if (process_mode == pm_call_graph) {
+	if (opts.process_mode == CscoutOptions::pm_call_graph) {
 		cerr << "Producing call graphs for: ";
-		for (string d : call_graphs) cerr << d << " ";
+		for (string d : opts.call_graphs) cerr << d << " ";
 		cerr << endl;
-		produce_call_graphs(call_graphs);
+		produce_call_graphs(opts.call_graphs);
 
 		return (0);
 	}
 
 	if (DP())
 		cout  << "Tokid EC map size is " << Tokid::map_size() << endl;
-	if (process_mode == pm_compile)
+	if (opts.process_mode == CscoutOptions::pm_compile)
 		return (0);
 	// Serve web pages
 	if (!must_exit)
-		cerr << "CScout is now ready to serve you at http://localhost:" << portno << endl;
+		cerr << "CScout is now ready to serve you at http://localhost:" << opts.portno << endl;
 	if (browse_only)
 		swill_setfork();
 	while (!must_exit)
@@ -3783,7 +3583,7 @@ garbage_collect(Fileid root)
 		Filedetails::set_required(fi, false);	// Mark the file as not being required
 		touched_files.insert(fi);
 
-		if (!monitor.is_valid()) {
+		if (!opts.monitor.is_valid()) {
 			Filedetails::set_garbage_collected(fi, true);	// Mark the file as garbage collected
 			continue;
 		}
@@ -3809,7 +3609,7 @@ garbage_collect(Fileid root)
 				sum++;
 				Eclass *ec = ei->second;
 				IdPropElem ec_id(ec, Identifier());
-				if (!monitor.eval(ec_id)) {
+				if (!opts.monitor.eval(ec_id)) {
 					count++;
 					ec->remove_from_tokid_map();
 					delete ec;
@@ -3831,7 +3631,7 @@ garbage_collect(Fileid root)
 	for (set <Fileid>::const_iterator i = touched_files.begin(); i != touched_files.end(); i++)
 		if (*i != root && *i != input_file_id)
 			Filedetails::set_includes(root, *i, /* directly included (conservatively) */ false, Filedetails::is_required(*i));
-	if (process_mode == pm_database)
+	if (opts.process_mode == CscoutOptions::pm_database)
 		Fdep::dumpSql(Sql::getInterface(), cout, root);
 	Fdep::reset();
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1,0 +1,237 @@
+/*
+ * (C) Copyright 2008-2026 Diomidis Spinellis
+ *
+ * This file is part of CScout.
+ *
+ * CScout is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CScout is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CScout.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * CScout invocation options.
+ *
+ */
+
+
+#include <iostream>
+#include <fstream>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#include <getopt.h>
+
+#include "cpp.h"
+#include "pdtoken.h"
+#include "fchar.h"
+#include "type.h"
+#include "ctag.h"
+#include "sql.h"
+#include "workdb.h"
+#include "compiledre.h"
+#include "dbtoken.h"
+#include "options.h"
+#include "util.h"
+
+using namespace std;
+
+// Report usage information and exit
+void
+usage(char *fname)
+{
+	cerr << "usage: " << fname <<
+		" ["
+#ifndef WIN32
+		"-b|"	// browse-only
+#endif
+		"-C|-c|-d D|-d H|-E RE|-o|-M files|"
+		"-q|-R URL|-r|-S db|-s db|-v] "
+		"[-l file] "
+
+#ifdef PICO_QL
+#define PICO_QL_OPTIONS "q"
+		"-q|"
+#else
+#define PICO_QL_OPTIONS ""
+#endif
+
+		"[-P RE] [-p port] [-m spec] [-t table ...] file\n"
+#ifndef WIN32
+		"\t-b\tRun in multiuser browse-only mode\n"
+#endif
+		"\t-C\tCreate a ctags(1)-compatible tags file\n"
+		"\t-c\tProcess the file and exit\n"
+		"\t-R URL\tOutput the call graphs specified by the URLs exit\n"
+		"\t-d D\tOutput the #defines being processed\n"
+		"\t-d H\tOutput the names of included files being processed\n"
+		"\t-E RE\tOutput preprocessed results and exit\n"
+		"\t\t(Will process file(s) matched by the regular expression)\n"
+		"\t-l file\tSpecify access log file\n"
+		"\t-M files\tMerge specified EC files\n"
+		"\t-m spec\tSpecify identifiers to monitor (unsound)\n"
+		"\t-o\tCreate obfuscated versions of the processed files\n"
+		"\t-P RE\tProcess only file(s) matched by the regular expression\n"
+		"\t-p port\tSpecify TCP port for serving the CScout web pages\n"
+		"\t\t(the port number must be in the range 1024-32767)\n"
+#ifdef PICO_QL
+		"\t-q\tProvide a PiCO_QL query interface\n"
+#else
+		"\t-q\tSuppress progress messages on standard error\n"
+#endif
+		"\t-r\tGenerate an identifier and include file warning report\n"
+		"\t-S db\tGenerate the SQL schema for the specified RDBMS\n"
+		"\t-s db\tGenerate SQL output for the specified RDBMS\n"
+		"\t-t table\tEnable population of the specified RDBMS table\n"
+		"\t\t(All enabled by default. Option can be provided multiple times)\n"
+		"\t-v\tDisplay version and copyright information and exit\n"
+		"\t-3\tEnable the handling of trigraph characters\n"
+		;
+	exit(1);
+}
+
+
+// Return a compiled RE for the string s, verifying its correctness
+static CompiledRE
+verified_compiled_re(const char *s)
+{
+	CompiledRE pre(s, REG_EXTENDED | REG_NOSUB);
+
+	if (!pre.isCorrect()) {
+		cerr << "Filename regular expression error:" <<
+			pre.getError() << '\n';
+		exit(1);
+	}
+	return pre;
+}
+
+void
+CscoutOptions::parse_args(int argc, char *argv[])
+{
+    int c;
+
+	while ((c = getopt(argc, argv, "3bCcd:rvE:P:p:Mm:l:oR:S:s:t:q" PICO_QL_OPTIONS)) != EOF)  //added q for quiet
+		switch (c) {
+		case '3':
+			Fchar::enable_trigraphs();
+			break;
+		case 'E':
+			if (!optarg || process_mode)
+				usage(argv[0]);
+			// Preprocess the specified file
+			Pdtoken::set_preprocessed_output(verified_compiled_re(optarg));
+			process_mode = pm_preprocess;
+			break;
+		case 'C':
+			CTag::enable();
+			break;
+		#ifdef PICO_QL
+		case 'q':
+			pico_ql = true;
+			/* FALLTHROUGH */
+		#endif
+		case 'c':
+			if (process_mode)
+				usage(argv[0]);
+			process_mode = pm_compile;
+			break;
+		case 'd':
+			if (!optarg)
+				usage(argv[0]);
+			switch (*optarg) {
+			case 'D':	// Similar to gcc -dD
+				Pdtoken::set_output_defines();
+				break;
+			case 'H':	// Similar to gcc -H
+				Fchar::set_output_headers();
+				break;
+			default:
+				usage(argv[0]);
+			}
+			break;
+		case 'p':
+			if (!optarg)
+				usage(argv[0]);
+			portno = atoi(optarg);
+			if (portno < 1024 || portno > 32767)
+				usage(argv[0]);
+			break;
+		case 'M':
+			do_merge = true;
+			break;
+		case 'm':
+			if (!optarg)
+				usage(argv[0]);
+			monitor = IdQuery(optarg);
+			break;
+		case 'r':
+			if (process_mode)
+				usage(argv[0]);
+			process_mode = pm_report;
+			break;
+		case 'v':
+			cout << version_info(false);
+			exit(0);
+		case 'b':
+			this->browse_only = true;
+			break;
+		case 'q':
+			quiet = true;
+			break;
+		case 'l':
+			if (!optarg)
+				usage(argv[0]);
+			log_file = optarg;
+			break;
+		case 'o':
+			if (process_mode)
+				usage(argv[0]);
+			process_mode = pm_obfuscation;
+			break;
+		case 'P':
+			if (!optarg)
+				usage(argv[0]);
+			// Process the specified file(s)
+			Pdtoken::set_processed_files(verified_compiled_re(optarg));
+			break;
+		case 'S':
+			if (process_mode)
+				usage(argv[0]);
+			if (!optarg)
+				usage(argv[0]);
+			db_engine = optarg;
+			if (!Sql::setEngine(optarg))
+				exit(1);
+			workdb_schema(Sql::getInterface(), cout);
+			exit(0);
+		case 's':
+			if (process_mode)
+				usage(argv[0]);
+			if (!optarg)
+				usage(argv[0]);
+			process_mode = pm_database;
+			db_engine = optarg;
+			break;
+		case 't':
+			if (!optarg)
+				usage(argv[0]);
+			table_enable(optarg);
+			break;
+		case 'R':
+			if (!optarg)
+				usage(argv[0]);
+			process_mode = pm_call_graph;
+			this->call_graphs.push_back(string(optarg));
+			break;
+		case '?':
+			usage(argv[0]);
+		}
+}

--- a/src/options.h
+++ b/src/options.h
@@ -1,0 +1,79 @@
+/*
+ * (C) Copyright 2008-2026 Diomidis Spinellis
+ *
+ * This file is part of CScout.
+ *
+ * CScout is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CScout is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CScout.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * CScout invocation options.
+ *
+ */
+
+#ifndef OPTIONS_H
+#define OPTIONS_H
+
+#include "idquery.h"
+#include <vector>
+#include <string>
+
+// Invocation options parsed from command line arguments
+class CscoutOptions {
+public:
+	// Processing mode set by command line flags
+	enum e_process {
+		pm_unspecified,		// Default (web front-end) must be 0
+		pm_preprocess,		// Preprocess-only (-E)
+		pm_compile,			// Compile-only (-c)
+		pm_report,			// Generate a warning report
+		pm_database,		// Generate SQL database
+		pm_obfuscation,		// Obfuscate source
+		pm_call_graph		// Generate call graphs
+	};
+
+	enum e_process process_mode;
+	int portno;
+	bool quiet;
+	std::string db_engine;
+	IdQuery monitor;
+	bool browse_only;
+	std::vector<std::string> call_graphs;
+	std::string log_file;
+	bool do_merge;
+	bool pico_ql;
+
+	CscoutOptions() :
+		process_mode(pm_unspecified),
+		portno(8081),
+		quiet(false),
+		browse_only(false),
+		do_merge(false),
+		pico_ql(false)
+	{}
+
+	void parse_args(int argc, char *argv[]);
+
+	bool is_quiet() const { return quiet; }
+
+	bool is_web_server_mode() const {
+		return process_mode != pm_compile
+			&& process_mode != pm_database
+			&& process_mode != pm_obfuscation
+			&& process_mode != pm_preprocess;
+	}
+};
+
+void usage(char *fname);
+
+#endif /* OPTIONS_H */


### PR DESCRIPTION
## Summary

Command line flags `portno`, `quiet`, `process_mode`, `db_engine`, `monitor`, `browse_only`, and `call_graphs` were separate static globals in `cscout.cpp`. This PR groups them into a `CscoutOptions` class and moves the entire argument parsing loop into a `parse_args` method, giving the class proper behavior beyond just holding values.

`main()` now creates a single `CscoutOptions` object and calls `parse_args`, making the startup sequence clear and explicit.

## Testing
All existing tests pass