### PR TITLE
Refactor: wire analysis functions as CscoutEngine methods and remove global state

### DIFF
--- a/src/cscout.cpp
+++ b/src/cscout.cpp
@@ -99,6 +99,7 @@ using namespace picoQL;
 #include "util.h"
 #include "options.h"
 #include "engine.h"
+
 CscoutOptions opts;
 CscoutEngine engine(opts);
 
@@ -442,9 +443,9 @@ xfilequery_page(FILE *of,  void *)
 
 	html_head(of, "xfilequery", (qname && *qname) ? qname : "File Query Results");
 
-	for (vector <Fileid>::const_iterator i = engine.get_files().begin(); i != engine.get_files().end(); i++) {
-		if (query.eval(*i))
-			sorted_files.insert(*i);
+	for (auto file : engine.get_files()) {
+		if (query.eval(file))
+			sorted_files.insert(file);
 	}
 	html_file_begin(of);
 	if (modification_state != ms_subst && !browse_only)
@@ -1373,13 +1374,14 @@ set_options_page(FILE *fo, void *p)
 	}
 	Option::set_all();
 	if (Option::sfile_re_string->get().length()) {
-		sfile_re = CompiledRE(Option::sfile_re_string->get().c_str(), REG_EXTENDED);
+		CompiledRE sfile_re(Option::sfile_re_string->get().c_str(), REG_EXTENDED);
 		if (!sfile_re.isCorrect()) {
 			html_head(fo, "regerror", "Regular Expression Error");
 			fprintf(fo, "<h2>Filename regular expression error</h2>%s", sfile_re.getError().c_str());
 			html_tail(fo);
 			return 0;
 		}
+		engine.set_sfile_re(sfile_re);
 	}
 	if (string(swill_getvar("set")) == "Apply")
 		return options_page(fo, p);
@@ -1422,10 +1424,12 @@ options_load()
 	}
 	Option::load_all(in);
 	if (Option::sfile_re_string->get().length()) {
-		sfile_re = CompiledRE(Option::sfile_re_string->get().c_str(), REG_EXTENDED);
+		CompiledRE sfile_re(Option::sfile_re_string->get().c_str(), REG_EXTENDED);
 		if (!sfile_re.isCorrect()) {
 			fprintf(stderr, "Filename regular expression error: %s", sfile_re.getError().c_str());
 			Option::sfile_re_string->erase();
+		} else {
+			engine.set_sfile_re(sfile_re);
 		}
 	}
 	in.close();
@@ -1677,17 +1681,17 @@ fgraph_page(GraphDisplay *gd)
 			edges.insert(edges.begin(), size, vector<bool>(size, 0));
 			// Fill the edges for all files
 			Filedetails::clear_all_visited();
-			for (vector <Fileid>::const_iterator i = engine.get_files().begin(); i != engine.get_files().end(); i++) {
-				if (Filedetails::is_visited(*i))
+			for (const auto &file : engine.get_files()) {
+				if (Filedetails::is_visited(file))
 					continue;
-				if (!all && i->get_readonly())
+				if (!all && file.get_readonly())
 					continue;
 				switch (*ltype) {
 				case 'D':
-					visit_fcall_files(*i, &Call::call_begin, &Call::call_end, Option::cgraph_depth->get(), edges);
+					visit_fcall_files(file, &Call::call_begin, &Call::call_end, Option::cgraph_depth->get(), edges);
 					break;
 				case 'U':
-					visit_fcall_files(*i, &Call::caller_begin, &Call::caller_end, Option::cgraph_depth->get(), edges);
+					visit_fcall_files(file, &Call::caller_begin, &Call::caller_end, Option::cgraph_depth->get(), edges);
 					break;
 				}
 			}
@@ -1701,24 +1705,25 @@ fgraph_page(GraphDisplay *gd)
 	}
 	int count = 0;
 	// First generate the node labels
-	for (vector <Fileid>::const_iterator i = engine.get_files().begin(); i != engine.get_files().end(); i++) {		if (!all && i->get_readonly())
+	for (const auto &file : engine.get_files()) {
+		if (!all && file.get_readonly())
 			continue;
-		if (only_visited && !Filedetails::is_visited(*i))
+		if (only_visited && !Filedetails::is_visited(file))
 			continue;
-		gd->node(*i);
+		gd->node(file);
 		if (browse_only && count++ >= MAX_BROWSING_GRAPH_ELEMENTS)
 			goto end;
 	}
 	// Now the edges
-	for (vector <Fileid>::const_iterator i = engine.get_files().begin(); i != engine.get_files().end(); i++) {
-		if (!all && i->get_readonly())
+	for (const auto &file : engine.get_files()) {
+		if (!all && file.get_readonly())
 			continue;
-		if (only_visited && !Filedetails::is_visited(*i))
+		if (only_visited && !Filedetails::is_visited(file))
 			continue;
 		switch (*gtype) {
 		case 'C':		// Compile-time dependency graph
 		case 'I': {		// Include graph
-			const FileIncMap &m(Filedetails::get_includes(*i));
+			const FileIncMap &m(Filedetails::get_includes(file));
 			for (FileIncMap::const_iterator j = m.begin(); j != m.end(); j++) {
 				if (*gtype == 'I' && !j->second.is_directly_included())
 					continue;
@@ -1728,29 +1733,29 @@ fgraph_page(GraphDisplay *gd)
 					continue;
 				if (only_visited && !Filedetails::is_visited(j->first))
 					continue;
-				gd->edge(j->first, *i);
+				gd->edge(j->first, file);
 				if (browse_only && count++ >= MAX_BROWSING_GRAPH_ELEMENTS)
 					goto end;
 			}
 			break;
 		}
 		case 'F':		// Function call graph (control dependency)
-			for (vector <Fileid>::const_iterator j = engine.get_files().begin(); j != engine.get_files().end(); j++) {				
-				if (!all && j->get_readonly())
+			for (const auto &file2 : engine.get_files()) {				
+				if (!all && file2.get_readonly())
 					continue;
-				if (only_visited && !Filedetails::is_visited(*j))
+				if (only_visited && !Filedetails::is_visited(file2))
 					continue;
-				if (*i == *j)
+				if (file == file2)
 					continue;
 				if (DP())
-					cout << "Checking " << i->get_fname() << " - " << j->get_fname() << endl;
-				if (edges[i->get_id()][j->get_id()])
+					cout << "Checking " << file.get_fname() << " - " << file2.get_fname() << endl;
+				if (edges[file.get_id()][file2.get_id()])
 					switch (*ltype) {
 					case 'D':
-						gd->edge(*j, *i);
+						gd->edge(file2, file);
 						break;
 					case 'U':
-						gd->edge(*i, *j);
+						gd->edge(file, file2);
 						break;
 					}
 				if (browse_only && count++ >= MAX_BROWSING_GRAPH_ELEMENTS)
@@ -1758,12 +1763,12 @@ fgraph_page(GraphDisplay *gd)
 			}
 			break;
 		case 'G':		// Global object def/ref graph (data dependency)
-			for (Fileidset::const_iterator j = Filedetails::get_glob_uses(*i).begin(); j != Filedetails::get_glob_uses(*i).end(); j++) {
+			for (Fileidset::const_iterator j = Filedetails::get_glob_uses(file).begin(); j != Filedetails::get_glob_uses(file).end(); j++) {
 				if (!all && j->get_readonly())
 					continue;
 				if (only_visited && !Filedetails::is_visited(*j))
 					continue;
-				gd->edge(*j, *i);
+				gd->edge(*j, file);
 				if (browse_only && count++ >= MAX_BROWSING_GRAPH_ELEMENTS)
 					goto end;
 			}
@@ -2490,7 +2495,7 @@ write_quit_page(FILE *of, void *exit)
 		    cerr << "Checking rename refactorings for name clashes." << endl;
 		Token::check_clashes = true;
 		// Reparse everything
-		Fchar::set_input(input_file_id.get_path());
+		Fchar::set_input(engine.get_input_file_path());
 		Error::set_parsing(true);
 		Pdtoken t;
 		do
@@ -2527,7 +2532,7 @@ write_quit_page(FILE *of, void *exit)
             html_perror(of, err);
     }
 	fprintf(of, "A total of %d replacements and %d function call refactorings were made in %d files.",
-	    num_id_replacements, num_fun_call_refactorings, (unsigned)(process.size()));
+		engine.get_num_id_replacements(), engine.get_num_fun_call_refactorings(), (unsigned)(process.size()));
 	if (exit) {
 		fprintf(of, "<p>Bye...</body></html>");
 		must_exit = true;
@@ -2645,14 +2650,14 @@ warning_report()
 	typedef map <int, SiteInfo> Sites;
 	Sites include_sites;
 
-	for (vector <Fileid>::iterator i = files.begin(); i != files.end(); i++) {
-		if (i->get_readonly() ||		// Don't report on RO files
-		    !Filedetails::is_compilation_unit(*i) ||		// Algorithm only works for CUs
-		    *i == input_file_id ||		// Don't report on main file
-		    Filedetails::get_includers(*i).size() > 1)	// For files that are both CUs and included
+	for (const auto &file : engine.get_files()) {
+		if (file.get_readonly() ||		// Don't report on RO files
+		    !Filedetails::is_compilation_unit(file) ||		// Algorithm only works for CUs
+		    file == engine.get_input_file_id() ||		// Don't report on main file
+		    Filedetails::get_includers(file).size() > 1)	// For files that are both CUs and included
 							// by others all bets are off
 			continue;
-		const FileIncMap &m = Filedetails::get_includes(*i);
+		const FileIncMap &m = Filedetails::get_includes(file);
 		// Find the status of our include sites
 		include_sites.clear();
 		for (FileIncMap::const_iterator j = m.begin(); j != m.end(); j++) {
@@ -2676,9 +2681,9 @@ warning_report()
 				const set <Fileid> &sf = (*si).second.get_files();
 				int line = (*si).first;
 				for (set <Fileid>::const_iterator fi = sf.begin(); fi != sf.end(); fi++)
-					cerr << i->get_path() << ':' <<
+					cerr << file.get_path() << ':' <<
 						line << ": " <<
-						"(" << Filedetails::get_pre_cpp_const_metrics(*i).get_int_metric(Metrics::em_nuline) << " unprocessed lines)"
+						"(" << Filedetails::get_pre_cpp_const_metrics(file).get_int_metric(Metrics::em_nuline) << " unprocessed lines)"
 						" unused included file " <<
 						fi->get_path() <<
 						endl;
@@ -2802,7 +2807,7 @@ main(int argc, char *argv[])
 	if (opts.process_mode == CscoutOptions::pm_preprocess)
 		return 0;
 
-	input_file_id = Fileid(argv[optind]);
+	engine.set_input_file_id(Fileid(argv[optind]));
 
 	Filedetails::unify_identical_files();
 
@@ -2810,7 +2815,7 @@ main(int argc, char *argv[])
 		return obfuscate();
 
 	// Pass 2: Create web pages
-	files = Fileid::files(true);
+	engine.collect_active_files();
 
 
 
@@ -2833,9 +2838,9 @@ main(int argc, char *argv[])
 	 * Set several file and function metrics.
 	 */
 	Call::populate_macro_map();
-	for (vector <Fileid>::iterator i = files.begin(); i != files.end(); i++) {
-		engine.file_analyze(*i);
-		dir_add_file(*i);
+	for (const auto &file : engine.get_files()) {
+		engine.file_analyze(file);
+		dir_add_file(file);
 	}
 
 	// Update file and function metrics

--- a/src/cscout.cpp
+++ b/src/cscout.cpp
@@ -100,6 +100,7 @@ using namespace picoQL;
 #include "options.h"
 #include "engine.h"
 CscoutOptions opts;
+CscoutEngine engine(opts);
 
 #define ids Identifier::ids
 
@@ -441,7 +442,7 @@ xfilequery_page(FILE *of,  void *)
 
 	html_head(of, "xfilequery", (qname && *qname) ? qname : "File Query Results");
 
-	for (vector <Fileid>::iterator i = files.begin(); i != files.end(); i++) {
+	for (vector <Fileid>::const_iterator i = engine.get_files().begin(); i != engine.get_files().end(); i++) {
 		if (query.eval(*i))
 			sorted_files.insert(*i);
 	}
@@ -1676,7 +1677,7 @@ fgraph_page(GraphDisplay *gd)
 			edges.insert(edges.begin(), size, vector<bool>(size, 0));
 			// Fill the edges for all files
 			Filedetails::clear_all_visited();
-			for (vector <Fileid>::iterator i = files.begin(); i != files.end(); i++) {
+			for (vector <Fileid>::const_iterator i = engine.get_files().begin(); i != engine.get_files().end(); i++) {
 				if (Filedetails::is_visited(*i))
 					continue;
 				if (!all && i->get_readonly())
@@ -1700,8 +1701,7 @@ fgraph_page(GraphDisplay *gd)
 	}
 	int count = 0;
 	// First generate the node labels
-	for (vector <Fileid>::iterator i = files.begin(); i != files.end(); i++) {
-		if (!all && i->get_readonly())
+	for (vector <Fileid>::const_iterator i = engine.get_files().begin(); i != engine.get_files().end(); i++) {		if (!all && i->get_readonly())
 			continue;
 		if (only_visited && !Filedetails::is_visited(*i))
 			continue;
@@ -1710,7 +1710,7 @@ fgraph_page(GraphDisplay *gd)
 			goto end;
 	}
 	// Now the edges
-	for (vector <Fileid>::iterator i = files.begin(); i != files.end(); i++) {
+	for (vector <Fileid>::const_iterator i = engine.get_files().begin(); i != engine.get_files().end(); i++) {
 		if (!all && i->get_readonly())
 			continue;
 		if (only_visited && !Filedetails::is_visited(*i))
@@ -1735,7 +1735,7 @@ fgraph_page(GraphDisplay *gd)
 			break;
 		}
 		case 'F':		// Function call graph (control dependency)
-			for (vector <Fileid>::iterator j = files.begin(); j != files.end(); j++) {
+			for (vector <Fileid>::const_iterator j = engine.get_files().begin(); j != engine.get_files().end(); j++) {				
 				if (!all && j->get_readonly())
 					continue;
 				if (only_visited && !Filedetails::is_visited(*j))
@@ -2523,7 +2523,7 @@ write_quit_page(FILE *of, void *exit)
 	    cerr << "Processing files" << endl;
     for (IFSet::const_iterator i = process.begin(); i != process.end(); i++) {
         string err;
-        if (!file_refactor(*i, err))
+        if (!engine.file_refactor(*i, err))
             html_perror(of, err);
     }
 	fprintf(of, "A total of %d replacements and %d function call refactorings were made in %d files.",
@@ -2834,7 +2834,7 @@ main(int argc, char *argv[])
 	 */
 	Call::populate_macro_map();
 	for (vector <Fileid>::iterator i = files.begin(); i != files.end(); i++) {
-		file_analyze(*i);
+		engine.file_analyze(*i);
 		dir_add_file(*i);
 	}
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -73,16 +73,13 @@
 #include "engine.h"
 #include "macro_arg_processor.h"
 
-extern CscoutOptions opts;
 #define ids Identifier::ids
 
 using namespace std;
 
-Fileid input_file_id;
-CompiledRE sfile_re;			// Saved files replacement location RE
-vector <Fileid> files;
 
 RefFunCall::store_type RefFunCall::store;
+CscoutEngine *CscoutEngine::instance = nullptr;
 
 
 // Boundaries of a function argument
@@ -92,10 +89,6 @@ struct ArgBound {
 
 typedef map <Tokid, vector <ArgBound> > ArgBoundMap;
 static ArgBoundMap argbounds_map;
-
-// Keep track of the number of replacements made when saving the files
-int num_id_replacements = 0;
-int num_fun_call_refactorings = 0;
 
 // Add identifiers of the file fi into ids
 // Collect metrics for the file and its functions
@@ -731,9 +724,15 @@ CscoutEngine::garbage_collect(Fileid root)
 	return;
 }
 
-extern CscoutEngine engine;
+void
+CscoutEngine::collect_active_files()
+{
+	files = Fileid::files(true);
+}
 
+// Free function wrapper for garbage_collect to maintain compatibility
+// with callers outside the engine (such as pdtoken.cpp)
 void garbage_collect(Fileid root)
 {
-    engine.garbage_collect(root);
+	CscoutEngine::get_instance().garbage_collect(root);
 }

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -102,7 +102,7 @@ int num_fun_call_refactorings = 0;
 // Populate the file's accociated files set
 // Return true if the file contains unused identifiers
 bool
-file_analyze(Fileid fi)
+CscoutEngine::file_analyze(Fileid fi)
 {
 	using namespace std::rel_ops;
 
@@ -242,8 +242,8 @@ file_analyze(Fileid fi)
 
 // Set the function argument boundaries for refactored
 // function calls for the specified file
-static void
-establish_argument_boundaries(const string &fname)
+void
+CscoutEngine::establish_argument_boundaries(const string &fname)
 {
 	Pltoken::set_context(cpp_normal);
 	Fchar::set_input(fname);
@@ -504,8 +504,8 @@ function_argument_replace(string::const_iterator begin, string::const_iterator e
  * Otherwise, return the part suitably renamed and with the
  * function arguments reordered.
  */
-static string
-get_refactored_part(fifstream &in, Fileid fid)
+std::string
+CscoutEngine::get_refactored_part(fifstream &in, Fileid fid)
 {
 	Tokid ti;
 	int val;
@@ -564,7 +564,7 @@ get_refactored_part(fifstream &in, Fileid fid)
 
 // Go through the file doing any refactorings needed
 bool
-file_refactor(Fileid fid, string &error_msg)
+CscoutEngine::file_refactor(Fileid fid, string &error_msg)
 {
 	string plain;
 	fifstream in;
@@ -652,7 +652,7 @@ file_refactor(Fileid fid, string &error_msg)
  * Called after processing each input file, for that file.
  */
 void
-garbage_collect(Fileid root)
+CscoutEngine::garbage_collect(Fileid root)
 {
 	vector <Fileid> files(Fileid::files(false));
 	set <Fileid> touched_files;
@@ -729,4 +729,11 @@ garbage_collect(Fileid root)
 	Fdep::reset();
 
 	return;
+}
+
+extern CscoutEngine engine;
+
+void garbage_collect(Fileid root)
+{
+    engine.garbage_collect(root);
 }

--- a/src/engine.h
+++ b/src/engine.h
@@ -61,32 +61,29 @@ public:
 
 typedef std::vector<std::vector<bool>> EdgeMatrix;
 
-// Keep track of the number of replacements made when saving the files
-extern int num_id_replacements;
-extern int num_fun_call_refactorings;
-extern Fileid input_file_id;
-extern CompiledRE sfile_re;				// Saved files replacement location RE
-extern std::vector<Fileid> files;
-
 // Analysis functions - defined in engine.cpp, called from cscout.cpp
-bool file_analyze(Fileid fi);
-bool file_refactor(Fileid fid, std::string &error_msg);
 bool is_function_call_replacement_valid(std::string::const_iterator begin, std::string::const_iterator end, const char **error);
 void garbage_collect(Fileid root);
-std::string get_refactored_part(fifstream &in, Fileid fid);
 
 class CscoutEngine {
 private:
+	static CscoutEngine *instance;	// Static pointer to the active engine instance
 	CscoutOptions &opts;			// Invocation options controlling monitor and process mode
 	std::vector<Fileid> files;		// All files in the analyzed workspace
 	Fileid input_file_id;			// Root input file passed on the command line
-	CompiledRE sfile_re;			// RE for mapping source file names to replacement paths
+	CompiledRE sfile_re;		 	// RE for mapping source file names to replacement paths
+	int num_id_replacements;		// Count of identifier replacements made during refactoring
+	int num_fun_call_refactorings;	// Count of function call argument reorderings made
 
 	void establish_argument_boundaries(const std::string &fname);
 	std::string get_refactored_part(fifstream &in, Fileid fid);
 
 public:
-	CscoutEngine(CscoutOptions &opts) : opts(opts) {}
+	CscoutEngine(CscoutOptions &opts) : opts(opts), num_id_replacements(0), num_fun_call_refactorings(0) {
+		instance = this;
+	}
+
+	static CscoutEngine &get_instance() { return *instance; }
 
 	bool file_analyze(Fileid fi);
 	bool file_refactor(Fileid fid, std::string &error_msg);
@@ -94,6 +91,17 @@ public:
 	void analyze_files(Fileid input);
 	// Return all files collected during workspace analysis
 	const std::vector<Fileid> &get_files() const { return files; }
+	// Return the root input file
+	const Fileid &get_input_file_id() const { return input_file_id; }
+	// Return the path of the root input file
+	const std::string &get_input_file_path() const { return input_file_id.get_path(); }
+	// Return identifier replacement count
+	int get_num_id_replacements() const { return num_id_replacements; }
+	// Return function call refactoring count
+	int get_num_fun_call_refactorings() const { return num_fun_call_refactorings; }
+	void collect_active_files();
+	void set_input_file_id(const Fileid &fid) { input_file_id = fid; }
+	void set_sfile_re(const CompiledRE &re) { sfile_re = re; }
 };
 
 #endif /* ENGINE_H */

--- a/src/engine.h
+++ b/src/engine.h
@@ -33,6 +33,7 @@
 #include "compiledre.h"
 #include "call.h"
 #include "eclass.h"
+#include "fifstream.h"
 
 // Forward declaration - defined in options.h
 class CscoutOptions;
@@ -72,19 +73,24 @@ bool file_analyze(Fileid fi);
 bool file_refactor(Fileid fid, std::string &error_msg);
 bool is_function_call_replacement_valid(std::string::const_iterator begin, std::string::const_iterator end, const char **error);
 void garbage_collect(Fileid root);
+std::string get_refactored_part(fifstream &in, Fileid fid);
 
 class CscoutEngine {
 private:
-	const CscoutOptions &opts;		// Invocation options controlling monitor and process mode
+	CscoutOptions &opts;			// Invocation options controlling monitor and process mode
 	std::vector<Fileid> files;		// All files in the analyzed workspace
 	Fileid input_file_id;			// Root input file passed on the command line
-	CompiledRE sfile_re;		 	// RE for mapping source file names to replacement paths
+	CompiledRE sfile_re;			// RE for mapping source file names to replacement paths
 
 	void establish_argument_boundaries(const std::string &fname);
+	std::string get_refactored_part(fifstream &in, Fileid fid);
 
 public:
-	CscoutEngine(const CscoutOptions &opts) : opts(opts) {}
+	CscoutEngine(CscoutOptions &opts) : opts(opts) {}
 
+	bool file_analyze(Fileid fi);
+	bool file_refactor(Fileid fid, std::string &error_msg);
+	void garbage_collect(Fileid root);
 	void analyze_files(Fileid input);
 	// Return all files collected during workspace analysis
 	const std::vector<Fileid> &get_files() const { return files; }


### PR DESCRIPTION
Follow up of #127 

Completes the `CscoutEngine` class by wiring the remaining analysis functions as class methods and moving all analysis state from globals into private members.

### Analysis functions as class methods

`file_analyze`, `file_refactor`, `establish_argument_boundaries`, `get_refactored_part`, and `garbage_collect` are now methods of `CscoutEngine`. A thin free function wrapper for `garbage_collect` is kept in `engine.cpp` since `pdtoken.cpp` calls it directly during parsing.

### Globals replaced by class members

`input_file_id`, `sfile_re`, `files`, `num_id_replacements`, and `num_fun_call_refactorings` were `extern` globals. They are now private members of `CscoutEngine` with getter and setter methods providing controlled access from `cscout.cpp`.

All existing tests pass.
