### PR TITLE
Fix HTML interface leak and update engine comment

### DIFF
--- a/src/cscout.cpp
+++ b/src/cscout.cpp
@@ -68,7 +68,6 @@
 #include "call.h"
 #include "fcall.h"
 #include "mcall.h"
-#include "compiledre.h"
 #include "option.h"
 #include "query.h"
 #include "mquery.h"
@@ -1374,14 +1373,13 @@ set_options_page(FILE *fo, void *p)
 	}
 	Option::set_all();
 	if (Option::sfile_re_string->get().length()) {
-		CompiledRE sfile_re(Option::sfile_re_string->get().c_str(), REG_EXTENDED);
-		if (!sfile_re.isCorrect()) {
+		string error_msg;
+		if (!engine.set_sfile_re(Option::sfile_re_string->get(), error_msg)) {
 			html_head(fo, "regerror", "Regular Expression Error");
-			fprintf(fo, "<h2>Filename regular expression error</h2>%s", sfile_re.getError().c_str());
+			fprintf(fo, "<h2>Filename regular expression error</h2>%s", error_msg.c_str());
 			html_tail(fo);
 			return 0;
 		}
-		engine.set_sfile_re(sfile_re);
 	}
 	if (string(swill_getvar("set")) == "Apply")
 		return options_page(fo, p);
@@ -1424,12 +1422,10 @@ options_load()
 	}
 	Option::load_all(in);
 	if (Option::sfile_re_string->get().length()) {
-		CompiledRE sfile_re(Option::sfile_re_string->get().c_str(), REG_EXTENDED);
-		if (!sfile_re.isCorrect()) {
-			fprintf(stderr, "Filename regular expression error: %s", sfile_re.getError().c_str());
+		string error_msg;
+		if (!engine.set_sfile_re(Option::sfile_re_string->get(), error_msg)) {
+			fprintf(stderr, "Filename regular expression error: %s", error_msg.c_str());
 			Option::sfile_re_string->erase();
-		} else {
-			engine.set_sfile_re(sfile_re);
 		}
 	}
 	in.close();

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -730,6 +730,18 @@ CscoutEngine::collect_active_files()
 	files = Fileid::files(true);
 }
 
+bool
+CscoutEngine::set_sfile_re(const std::string &re_str, std::string &error_msg)
+{
+	CompiledRE re(re_str.c_str(), REG_EXTENDED);
+	if (!re.isCorrect()) {
+		error_msg = re.getError();
+		return false;
+	}
+	sfile_re = re;
+	return true;
+}
+
 // Free function wrapper for garbage_collect to maintain compatibility
 // with callers outside the engine (such as pdtoken.cpp)
 void garbage_collect(Fileid root)

--- a/src/engine.h
+++ b/src/engine.h
@@ -67,7 +67,7 @@ void garbage_collect(Fileid root);
 
 class CscoutEngine {
 private:
-	static CscoutEngine *instance;	// Static pointer to the active engine instance
+	static CscoutEngine *instance;	// Class pointer to the active engine instance
 	CscoutOptions &opts;			// Invocation options controlling monitor and process mode
 	std::vector<Fileid> files;		// All files in the analyzed workspace
 	Fileid input_file_id;			// Root input file passed on the command line
@@ -101,7 +101,7 @@ public:
 	int get_num_fun_call_refactorings() const { return num_fun_call_refactorings; }
 	void collect_active_files();
 	void set_input_file_id(const Fileid &fid) { input_file_id = fid; }
-	void set_sfile_re(const CompiledRE &re) { sfile_re = re; }
+	bool set_sfile_re(const std::string &re_str, std::string &error_msg);
 };
 
 #endif /* ENGINE_H */


### PR DESCRIPTION
Addresses review on #129 

### Changes:
*  `cscout.cpp` previously compiled the regular expression and checked it for errors locally, which leaked `CompiledRE` into the web interface. I modified `CscoutEngine::set_sfile_re` to accept a raw `std::string` and compile the regex internally. As a result, `cscout.cpp` no longer `#include`s or manages `CompiledRE` directly.
* Changed the `instance` pointer comment in `engine.h` to "Class pointer" instead of "Static pointer" to avoid C++ keyword ambiguity.

All tests pass locally.
