### PR TITLE
Add csapi REST server for querying CScout SQLite databases

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,7 +1,7 @@
 DESTDIR=/dds/pubs/web/home/cscout
 NOTETOOLS=/dds/pubs/courses/tools
 MANDOC=mancscout.xml mancswc.xml mancsmake.xml mancscc.xml mancscut.xml \
-       mancssplit.xml mancsmerge.xml mancsreconst.xml mancscoco.xml
+       mancssplit.xml mancsmerge.xml mancsreconst.xml mancscoco.xml mancsapi.xml
 
 .SUFFIXES:.java .dot .ps .gif .pic .eps .png .1
 

--- a/doc/api.xml
+++ b/doc/api.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<notes>
+<em>CScout</em> includes a REST API server (<code>csapi</code>)
+that allows other tools, such as IDE extensions, to query analysis results
+programmatically.
+<p />
+The server exposes CScout's SQL database as JSON-formatted HTTP endpoints.
+The API is documented using the OpenAPI standard in <code>doc/csapi.yaml</code>.
+You can also view this documentation in an interactive, human-readable HTML form
+by opening <code>doc/csapi.html</code> in your web browser.
+</notes>

--- a/doc/csapi.html
+++ b/doc/csapi.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>CScout REST API Specification</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+    }
+  </style>
+</head>
+
+<body>
+  <redoc spec-url='csapi.yaml'></redoc>
+  <script src="https://unpkg.com/redoc@2/bundles/redoc.standalone.js"></script>
+</body>
+
+</html>

--- a/doc/csapi.yaml
+++ b/doc/csapi.yaml
@@ -73,13 +73,17 @@ paths:
           in: query
           description: Identifiers appearing in more than one file.
           schema: { type: boolean }
-        - name: should_be_static
+        - name: not_file_spanning
           in: query
-          description: Writable ordinary project-scope identifiers that do not span files.
+          description: Identifiers that do not span files.
           schema: { type: boolean }
         - name: name
           in: query
           description: Substring match on identifier name.
+          schema: { type: string }
+        - name: name_ne
+          in: query
+          description: Exact negative match on identifier name.
           schema: { type: string }
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/offset'
@@ -229,96 +233,43 @@ paths:
 
   /files:
     get:
-      summary: List all files
+      summary: List all files with optional filters
+      parameters:
+        - name: writable
+          in: query
+          description: Writable files only (RO=0)
+          schema: { type: integer }
+        - name: ro
+          in: query
+          description: Read-only files only (RO=1)
+          schema: { type: integer }
+        - name: fre
+          in: query
+          description: Filter filenames matching SQL LIKE pattern
+          schema: { type: string }
+        - name: has_unused
+          in: query
+          description: Files containing unused writable identifiers
+          schema: { type: integer }
+        - name: no_statements
+          in: query
+          description: Writable .c files with no statements (NSTMT=0)
+          schema: { type: integer }
+        - name: unprocessed
+          in: query
+          description: Files with unprocessed lines (NULINE>0)
+          schema: { type: integer }
+        - name: has_strings
+          in: query
+          description: Files containing string literals (NSTRING>0)
+          schema: { type: integer }
+        - name: h_with_includes
+          in: query
+          description: Writable .h files with #include directives
+          schema: { type: integer }
       responses:
         '200':
-          description: List of all files in the workspace
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/File'
-
-  /files/writable:
-    get:
-      summary: Writable files
-      responses:
-        '200':
-          description: Files with RO=0
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/File'
-
-  /files/readonly:
-    get:
-      summary: Read-only files
-      responses:
-        '200':
-          description: Files with RO=1
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/File'
-
-  /files/with-unused:
-    get:
-      summary: Writable files containing unused identifiers
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/File'
-
-  /files/no-statements:
-    get:
-      summary: Writable .c files with no statements
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/File'
-
-  /files/unprocessed:
-    get:
-      summary: Writable files with unprocessed lines
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/File'
-
-  /files/with-strings:
-    get:
-      summary: Writable files containing string literals
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/File'
-
-  /files/h-with-includes:
-    get:
-      summary: Writable .h files with #include directives
-      responses:
-        '200':
+          description: List of files matching the filters
           content:
             application/json:
               schema:
@@ -667,7 +618,7 @@ paths:
         '400':
           description: Missing pid parameter
 
-  /refactor/preview:
+  /rename/preview:
     get:
       summary: Preview identifier rename
       description: Shows all token locations that would be changed. Does not modify files.
@@ -700,7 +651,7 @@ paths:
         '404':
           description: Identifier not found
 
-  /refactor/apply:
+  /rename/apply:
     get:
       summary: Apply identifier rename
       description: Performs byte-precise rename across all writable source files. Modifies files on disk.

--- a/doc/csapi.yaml
+++ b/doc/csapi.yaml
@@ -1,0 +1,849 @@
+openapi: 3.0.0
+info:
+  title: CScout REST API
+  description: REST API server for querying a CScout SQLite database.
+  version: 1.0.0
+servers:
+  - url: http://localhost:8081
+    description: Default local server
+
+paths:
+  /status:
+    get:
+      summary: Server health check
+      responses:
+        '200':
+          description: Server is running
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+                  indexes_ready:
+                    type: boolean
+
+  /quit:
+    get:
+      summary: Stop the server
+      responses:
+        '200':
+          description: Shutdown initiated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: quit
+
+  /identifiers:
+    get:
+      summary: Search identifiers
+      description: List identifiers matching the specified filters. Supports pagination.
+      parameters:
+        - name: unused
+          in: query
+          schema: { type: boolean }
+        - name: macro
+          in: query
+          schema: { type: boolean }
+        - name: fun
+          in: query
+          schema: { type: boolean }
+        - name: readonly
+          in: query
+          schema: { type: boolean }
+        - name: lscope
+          in: query
+          schema: { type: boolean }
+        - name: cscope
+          in: query
+          schema: { type: boolean }
+        - name: macroarg
+          in: query
+          schema: { type: boolean }
+        - name: ordinary
+          in: query
+          schema: { type: boolean }
+        - name: file_spanning
+          in: query
+          description: Identifiers appearing in more than one file.
+          schema: { type: boolean }
+        - name: should_be_static
+          in: query
+          description: Writable ordinary project-scope identifiers that do not span files.
+          schema: { type: boolean }
+        - name: name
+          in: query
+          description: Substring match on identifier name.
+          schema: { type: string }
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: List of identifiers
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Identifier'
+
+  /identifier:
+    get:
+      summary: Get identifier token locations
+      parameters:
+        - name: eid
+          in: query
+          required: true
+          schema: { type: integer }
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: Identifier details and paged token locations
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  identifier:
+                    $ref: '#/components/schemas/Identifier'
+                  locations:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Location'
+        '400':
+          description: Missing eid parameter
+        '404':
+          description: Identifier not found
+
+  /identifier/detail:
+    get:
+      summary: Get full identifier detail
+      description: Returns attributes, occurrence count, projects, dependent files, associated functions, and function detail.
+      parameters:
+        - name: eid
+          in: query
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: Full identifier detail
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  identifier:
+                    $ref: '#/components/schemas/Identifier'
+                  occurrences:
+                    type: integer
+                  locations:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Location'
+                  projects:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Project'
+                  dependent_files:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/File'
+                  associated_functions:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Function'
+                  function_detail:
+                    nullable: true
+                    type: object
+        '400':
+          description: Missing eid parameter
+        '404':
+          description: Identifier not found
+
+  /identifiers/counts:
+    get:
+      summary: Identifier counts per category
+      description: Returns COUNT(*) for each identifier sidebar category in one query.
+      responses:
+        '200':
+          description: Category counts
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  all: { type: integer }
+                  readonly: { type: integer }
+                  writable: { type: integer }
+                  file_spanning: { type: integer }
+                  unused_project: { type: integer }
+                  unused_file: { type: integer }
+                  unused_macros: { type: integer }
+                  static_vars: { type: integer }
+                  static_funs: { type: integer }
+
+  /attributes/identifiers:
+    get:
+      summary: Identifier attribute metadata
+      description: Returns attribute names and corresponding IDS column ids, read from METADATA table or built-in defaults.
+      responses:
+        '200':
+          description: List of attribute id/name pairs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: DB column name in IDS table
+                    name:
+                      type: string
+                      description: Human-readable attribute name
+
+  /attributes/files:
+    get:
+      summary: File metric attribute metadata
+      description: Returns file metric names and corresponding FILEMETRICS column ids.
+      responses:
+        '200':
+          description: List of metric id/name pairs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: { type: string }
+                    name: { type: string }
+
+  /files:
+    get:
+      summary: List all files
+      responses:
+        '200':
+          description: List of all files in the workspace
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/File'
+
+  /files/writable:
+    get:
+      summary: Writable files
+      responses:
+        '200':
+          description: Files with RO=0
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/File'
+
+  /files/readonly:
+    get:
+      summary: Read-only files
+      responses:
+        '200':
+          description: Files with RO=1
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/File'
+
+  /files/with-unused:
+    get:
+      summary: Writable files containing unused identifiers
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/File'
+
+  /files/no-statements:
+    get:
+      summary: Writable .c files with no statements
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/File'
+
+  /files/unprocessed:
+    get:
+      summary: Writable files with unprocessed lines
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/File'
+
+  /files/with-strings:
+    get:
+      summary: Writable files containing string literals
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/File'
+
+  /files/h-with-includes:
+    get:
+      summary: Writable .h files with #include directives
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/File'
+
+  /files/counts:
+    get:
+      summary: File counts per category
+      responses:
+        '200':
+          description: Category counts
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  all: { type: integer }
+                  readonly: { type: integer }
+                  writable: { type: integer }
+                  with_unused: { type: integer }
+                  no_statements: { type: integer }
+                  unprocessed: { type: integer }
+                  with_strings: { type: integer }
+                  h_with_includes: { type: integer }
+
+  /file/detail:
+    get:
+      summary: Full file detail
+      description: Returns file attributes, metrics, defined functions, included files, and files that include it.
+      parameters:
+        - name: fid
+          in: query
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: File detail
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  file:
+                    $ref: '#/components/schemas/File'
+                  metrics:
+                    type: object
+                  functions:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Function'
+                  includes:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/File'
+                  included_by:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/File'
+        '400':
+          description: Missing fid parameter
+        '404':
+          description: File not found
+
+  /filemetrics:
+    get:
+      summary: File metrics
+      parameters:
+        - name: fid
+          in: query
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: Pre-cpp and post-cpp metrics rows for the file
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FileMetrics'
+        '400':
+          description: Missing fid parameter
+        '404':
+          description: File not found
+
+  /filemetrics/aggregate:
+    get:
+      summary: All file metrics rows
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FileMetrics'
+
+  /filegraph/include:
+    get:
+      summary: File include dependency graph (SVG)
+      parameters:
+        - name: writable
+          in: query
+          description: Limit to writable files only.
+          schema: { type: boolean }
+      responses:
+        '200':
+          description: HTML page containing an SVG graphviz graph
+          content:
+            text/html:
+              schema:
+                type: string
+
+  /filegraph/compile:
+    get:
+      summary: Compile-time dependency graph (SVG)
+      parameters:
+        - name: writable
+          in: query
+          schema: { type: boolean }
+      responses:
+        '200':
+          content:
+            text/html:
+              schema:
+                type: string
+
+  /filegraph/control:
+    get:
+      summary: Control dependency graph via function calls (SVG)
+      parameters:
+        - name: writable
+          in: query
+          schema: { type: boolean }
+      responses:
+        '200':
+          content:
+            text/html:
+              schema:
+                type: string
+
+  /filegraph/data:
+    get:
+      summary: Data dependency graph via global variables (SVG)
+      parameters:
+        - name: writable
+          in: query
+          schema: { type: boolean }
+      responses:
+        '200':
+          content:
+            text/html:
+              schema:
+                type: string
+
+  /functions:
+    get:
+      summary: Search functions
+      parameters:
+        - name: defined
+          in: query
+          schema: { type: boolean }
+        - name: filescoped
+          in: query
+          schema: { type: boolean }
+        - name: ismacro
+          in: query
+          schema: { type: boolean }
+        - name: fanin
+          in: query
+          description: Exact fan-in value.
+          schema: { type: integer }
+        - name: max_fanin
+          in: query
+          description: Maximum fan-in value (inclusive).
+          schema: { type: integer }
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: List of functions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Function'
+
+  /functions/byname:
+    get:
+      summary: Get a function by name
+      parameters:
+        - name: name
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: The first matching defined function, or null
+          content:
+            application/json:
+              schema:
+                nullable: true
+                allOf:
+                  - $ref: '#/components/schemas/Function'
+
+  /functions/counts:
+    get:
+      summary: Function counts per category
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  all: { type: integer }
+                  project_scoped: { type: integer }
+                  file_scoped: { type: integer }
+                  not_called: { type: integer }
+                  called_once: { type: integer }
+
+  /funmetrics:
+    get:
+      summary: Function metrics
+      parameters:
+        - name: fnid
+          in: query
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: Pre-cpp and post-cpp metrics rows for the function
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FunctionMetrics'
+        '400':
+          description: Missing fnid parameter
+        '404':
+          description: Function not found
+
+  /funmetrics/aggregate:
+    get:
+      summary: All function metrics rows
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FunctionMetrics'
+
+  /callers:
+    get:
+      summary: Functions that call a given function
+      parameters:
+        - name: fnid
+          in: query
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CallInfo'
+        '400':
+          description: Missing fnid parameter
+
+  /callees:
+    get:
+      summary: Functions called by a given function
+      parameters:
+        - name: fnid
+          in: query
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CallInfo'
+        '400':
+          description: Missing fnid parameter
+
+  /callgraph:
+    get:
+      summary: Call graph for a function (SVG)
+      description: Renders a direct caller/callee call graph via graphviz. Requires graphviz to be installed.
+      parameters:
+        - name: fnid
+          in: query
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: HTML page containing an SVG call graph
+          content:
+            text/html:
+              schema:
+                type: string
+        '400':
+          description: Missing fnid parameter
+        '404':
+          description: Function not found
+
+  /projects:
+    get:
+      summary: List projects
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Project'
+
+  /project/files:
+    get:
+      summary: Files belonging to a project
+      parameters:
+        - name: pid
+          in: query
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/File'
+        '400':
+          description: Missing pid parameter
+
+  /refactor/preview:
+    get:
+      summary: Preview identifier rename
+      description: Shows all token locations that would be changed. Does not modify files.
+      parameters:
+        - name: eid
+          in: query
+          required: true
+          schema: { type: integer }
+        - name: newname
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  eid: { type: integer }
+                  old_name: { type: string }
+                  new_name: { type: string }
+                  total_replacements: { type: integer }
+                  locations:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Location'
+        '400':
+          description: Missing required parameter
+        '404':
+          description: Identifier not found
+
+  /refactor/apply:
+    get:
+      summary: Apply identifier rename
+      description: Performs byte-precise rename across all writable source files. Modifies files on disk.
+      parameters:
+        - name: eid
+          in: query
+          required: true
+          schema: { type: integer }
+        - name: newname
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  old_name: { type: string }
+                  new_name: { type: string }
+                  modified_files:
+                    type: array
+                    items:
+                      type: string
+                  total_replacements: { type: integer }
+        '400':
+          description: Missing required parameter
+        '404':
+          description: Identifier not found
+
+components:
+  parameters:
+    limit:
+      name: limit
+      in: query
+      description: Maximum number of results (default 1000).
+      schema:
+        type: integer
+        default: 1000
+    offset:
+      name: offset
+      in: query
+      description: Number of results to skip.
+      schema:
+        type: integer
+        default: 0
+
+  schemas:
+    Identifier:
+      type: object
+      description: Row from the IDS table.
+      properties:
+        EID:       { type: integer, description: Equivalence class identifier key }
+        NAME:      { type: string,  description: Identifier name }
+        READONLY:  { type: integer, description: "1 if it appears in at least one read-only file" }
+        UNDEFMACRO:       { type: integer, description: "1 if apparently an undefined macro" }
+        UNDEFEDMACRO:     { type: integer, description: "1 if the macro has been #undefed" }
+        REDEFEDSAMEMACRO: { type: integer, description: "1 if redefined with same value" }
+        REDEFEDDIFFMACRO: { type: integer, description: "1 if redefined with a different value" }
+        MACRO:     { type: integer, description: "1 if a preprocessor macro" }
+        FUNMACRO:  { type: integer, description: "1 if a function-like macro" }
+        MACROARG:  { type: integer, description: "1 if a macro argument" }
+        ORDINARY:  { type: integer, description: "1 if an ordinary identifier (variable or function)" }
+        SUETAG:    { type: integer, description: "1 if a struct/union/enum tag" }
+        SUMEMBER:  { type: integer, description: "1 if a struct/union member" }
+        LABEL:     { type: integer, description: "1 if a label" }
+        TYPEDEF:   { type: integer, description: "1 if a typedef" }
+        ENUM:      { type: integer, description: "1 if an enumeration member" }
+        YACC:      { type: integer, description: "1 if a yacc identifier" }
+        FUN:       { type: integer, description: "1 if a function name" }
+        CSCOPE:    { type: integer, description: "1 if its scope is a compilation unit (file scope)" }
+        LSCOPE:    { type: integer, description: "1 if it has linkage scope (project scope)" }
+        UNUSED:    { type: integer, description: "1 if it is not used" }
+        XFILE:     { type: integer, description: "1 if it crosses file boundaries" }
+
+    Location:
+      type: object
+      properties:
+        FID:     { type: integer }
+        FILE:    { type: string }
+        FOFFSET: { type: integer }
+        LNUM:    { type: integer }
+        RO:      { type: integer }
+
+    File:
+      type: object
+      description: Row from the FILES table.
+      properties:
+        FID:  { type: integer, description: Unique file key }
+        NAME: { type: string,  description: Full file path }
+        RO:   { type: integer, description: "1 if the file is read-only" }
+
+    FileMetrics:
+      type: object
+      description: "Row from the FILEMETRICS table. FID and PRECPP identify the row; remaining columns are metric values."
+      properties:
+        FID:    { type: integer }
+        PRECPP: { type: integer, description: "1 for pre-cpp values, 0 for post-cpp values" }
+      additionalProperties:
+        type: integer
+        description: Metric value column (e.g. NSTMT, NCHAR, NLINE, etc.)
+
+    Function:
+      type: object
+      description: Row from the FUNCTIONS table, joined with metrics and file info.
+      properties:
+        ID:         { type: integer, description: Unique function key }
+        NAME:       { type: string }
+        ISMACRO:    { type: integer, description: "1 if a function-like macro" }
+        DEFINED:    { type: integer, description: "1 if defined in the workspace" }
+        DECLARED:   { type: integer, description: "1 if declared in the workspace" }
+        FILESCOPED: { type: integer, description: "1 if file-scoped (static or macro)" }
+        FID:        { type: integer }
+        FOFFSET:    { type: integer }
+        FANIN:      { type: integer, description: Number of callers }
+        FANOUT:     { type: integer, description: Number of callees (from FUNCTIONMETRICS) }
+        CCYCL1:     { type: integer, description: McCabe cyclomatic complexity (from FUNCTIONMETRICS) }
+        FILE:       { type: string,  description: File path (joined from FILES) }
+        LNUM:       { type: integer, description: Line number (joined from LINEPOS) }
+
+    FunctionMetrics:
+      type: object
+      description: "Row from the FUNCTIONMETRICS table. FUNCTIONID and PRECPP identify the row."
+      properties:
+        FUNCTIONID: { type: integer }
+        PRECPP:     { type: integer, description: "1 for pre-cpp values, 0 for post-cpp values" }
+      additionalProperties:
+        type: number
+        description: Metric value column (e.g. FANOUT, CCYCL1, NSTMT, etc.)
+
+    CallInfo:
+      type: object
+      properties:
+        ID:      { type: integer }
+        NAME:    { type: string }
+        FID:     { type: integer }
+        FOFFSET: { type: integer }
+        FILE:    { type: string }
+
+    Project:
+      type: object
+      description: Row from the PROJECTS table.
+      properties:
+        PID:  { type: integer }
+        NAME: { type: string }

--- a/doc/index.xml
+++ b/doc/index.xml
@@ -35,12 +35,14 @@
 <ch><ti>SQL Back-end</ti><fi>sql</fi></ch>
 <ch><ti>Schema of the Generated Database</ti><fi>dbschema</fi></ch>
 <ch><ti>Examples of SQL Queries</ti><fi>qeg</fi></ch>
+<ch><ti>REST API Specification</ti><fi>api</fi></ch>
 <ch><ti>Source Code Reconstitution</ti><fi>reconst</fi></ch>
 <ch><ti>Details of the Collected Metrics</ti><fi>metrics</fi></ch>
 <ch><ti>Shortcomings</ti><fi>short</fi></ch>
 <ch><ti>Error Messages</ti><fi>error</fi></ch>
 <ch><ti>License</ti><fi>license</fi></ch>
 <ch><ti>Frequently Asked Questions</ti><fi>faq</fi></ch>
+<ch><ti>The csapi Command Manual Page</ti><fi>mancsapi</fi></ch>
 <ch><ti>The cscc Command Manual Page</ti><fi>mancscc</fi></ch>
 <ch><ti>The cscoco Command Manual Page</ti><fi>mancscoco</fi></ch>
 <ch><ti>The cscout Command Manual Page</ti><fi>mancscout</fi></ch>

--- a/man/Makefile
+++ b/man/Makefile
@@ -1,5 +1,5 @@
 all: cscout.pdf cswc.pdf csmake.pdf cscc.pdf cscut.pdf cssplit.pdf \
-	csreconst.pdf csmerge.pdf cscoco.pdf
+	csreconst.pdf csmerge.pdf cscoco.pdf csapi.pdf
 
 %.pdf: %.1
 	groff -Tps -man <$< >$$.ps

--- a/man/csapi.1
+++ b/man/csapi.1
@@ -1,0 +1,113 @@
+.TH CSAPI 1 "7 July 2026"
+.\"
+.\" (C) Copyright 2008-2026 Diomidis Spinellis
+.\" (C) Copyright 2026 Ujjwal Aggarwal
+.\"
+.\" This file is part of CScout.
+.\"
+.\" CScout is free software: you can redistribute it and/or modify
+.\" it under the terms of the GNU General Public License as published by
+.\" the Free Software Foundation, either version 3 of the License, or
+.\" (at your option) any later version.
+.\"
+.\" CScout is distributed in the hope that it will be useful,
+.\" but WITHOUT ANY WARRANTY; without even the implied warranty of
+.\" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+.\" GNU General Public License for more details.
+.\"
+.\" You should have received a copy of the GNU General Public License
+.\" along with CScout.  If not, see <http://www.gnu.org/licenses/>.
+.\"
+.SH NAME
+csapi \- REST API server for querying a CScout SQLite database
+.SH SYNOPSIS
+.B csapi
+.RB [ \-h ]
+.RB [ \-p
+.IR port ]
+.I db
+.SH DESCRIPTION
+.B csapi
+starts a lightweight REST API server to query a CScout SQLite database.
+The database can be produced by running
+.IR cscout (1)
+with the
+.B \-s sqlite
+option, or with
+.IR csmerge (1).
+.PP
+The server listens on
+.B localhost
+(127.0.0.1) only and is intended for use by local tools such as the CScout
+VS Code extension, CI scripts, and other programs that consume CScout
+whole-program C analysis data.
+.PP
+Upon startup, the database is verified. Database indexes are dynamically
+created on demand when query requests are processed, ensuring high-performance lookups.
+.SH OPTIONS
+.TP
+.BR \-h ", " \-\-help
+Display a brief usage message and exit.
+.TP
+.BR \-p ", " \-\-port " " \fIport\fR
+The port to listen on.
+Defaults to 8081.
+.SH ARGUMENTS
+.TP
+.I db
+Path to the SQLite database file containing the CScout analysis dataset.
+.SH ENDPOINTS
+The HTTP GET endpoints exposed by the server (such as
+.B /status\fR,
+.B /quit\fR,
+.B /identifiers\fR,
+.B /identifier\fR,
+.B /files\fR,
+.B /functions\fR,
+and
+.B /refactor/preview\fR)
+are documented in detail using the OpenAPI standard.
+For a complete reference of all endpoints, parameters, and response schemas, see the OpenAPI specification file:
+.I doc/csapi.yaml
+or open the interactive documentation viewer:
+.I doc/csapi.html
+in your web browser.
+.SH EXAMPLE
+Generate a CScout database from a project and start the API server:
+.PP
+.DS
+.ft C
+.nf
+cscout \-s sqlite project.cs | sqlite3 project.db
+csapi project.db \-p 8080
+.ft P
+.fi
+.DE
+.PP
+Query unused identifiers:
+.PP
+.DS
+.ft C
+.nf
+curl http://localhost:8080/identifiers?unused=true
+.ft P
+.fi
+.DE
+.PP
+Preview renaming an identifier:
+.PP
+.DS
+.ft C
+.nf
+curl "http://localhost:8080/refactor/preview?eid=12345&newname=new_name"
+.ft P
+.fi
+.DE
+.SH "SEE ALSO"
+\fIcscout\fP(1),
+\fIcsmake\fP(1),
+\fIcscoco\fP(1),
+\fIcssplit\fP(1),
+\fIcsmerge\fP(1)
+.SH AUTHOR
+(C) Copyright 2026 Diomidis Spinellis and Ujjwal Aggarwal.

--- a/man/csapi.1
+++ b/man/csapi.1
@@ -65,7 +65,7 @@ The HTTP GET endpoints exposed by the server (such as
 .B /files\fR,
 .B /functions\fR,
 and
-.B /refactor/preview\fR)
+.B /rename/preview\fR)
 are documented in detail using the OpenAPI standard.
 For a complete reference of all endpoints, parameters, and response schemas, see the OpenAPI specification file:
 .I doc/csapi.yaml
@@ -99,7 +99,7 @@ Preview renaming an identifier:
 .DS
 .ft C
 .nf
-curl "http://localhost:8080/refactor/preview?eid=12345&newname=new_name"
+curl "http://localhost:8080/rename/preview?eid=12345&newname=new_name"
 .ft P
 .fi
 .DE

--- a/src/Makefile
+++ b/src/Makefile
@@ -221,6 +221,7 @@ test:
 	./runtest.sh $(TEST_FLAGS)
 	cd test/csmake && ./runtest.sh
 	make -C csmerge test
+	python3 test_csapi.py
 
 tags:
 	ctags *.cpp *.h *.y
@@ -276,6 +277,7 @@ install: build/cscout
 	for i in ../man/*.1 ; do install -m 644 $$i $(MANDIR) ; done
 
 uninstall:
+	rm -f "$(PREFIX)/bin/csapi"
 	rm -f "$(PREFIX)/bin/cscc"
 	rm -f "$(PREFIX)/bin/cscout"
 	rm -f "$(PREFIX)/bin/csmake"

--- a/src/csapi.py
+++ b/src/csapi.py
@@ -1,0 +1,1373 @@
+#!/usr/bin/env python3
+#
+# (C) Copyright 2008-2026 Diomidis Spinellis
+# (C) Copyright 2026 Ujjwal Aggarwal
+#
+# This file is part of CScout.
+#
+# CScout is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# CScout is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CScout.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+# csapi.py -- REST API server for querying a CScout SQLite database.
+#
+# After running:
+#   cscout -s sqlite project.cs | sqlite3 project.db
+# start this server with:
+#   csapi project.db
+#
+# The server listens on localhost:8081 by default and exposes
+# CScout analysis results as JSON.
+#
+# No external dependencies -- uses only the Python standard library.
+#
+
+import argparse
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlparse
+
+class MissingParameterError(ValueError):
+    """Exception raised when a required query parameter is missing or invalid."""
+    pass
+
+
+def ensure_index(conn: sqlite3.Connection, table: str, columns: list) -> None:
+    """Ensure that an index exists on the specified table and columns."""
+    index_name = f"idx_{table.lower()}_{'_'.join(columns).lower()}"
+    columns_str = ", ".join(columns)
+    conn.execute(f"CREATE INDEX IF NOT EXISTS {index_name} ON {table}({columns_str})")
+
+
+def get_db() -> sqlite3.Connection:
+    """Open and return a new database connection."""
+    conn = sqlite3.connect(_db_path, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def rows_to_list(rows) -> list:
+    """Convert SQLite Row objects into standard Python dictionaries."""
+    return [dict(r) for r in rows]
+
+
+def get_param(qs, name, default=None):
+    """Get a single string query parameter value by name."""
+    vals = qs.get(name)
+    return vals[0] if vals else default
+
+
+def get_bool_param(qs, name):
+    """Get a query parameter value and convert it to a boolean."""
+    v = get_param(qs, name)
+    if v is None:
+        return None
+    return v.lower() in ("1", "true", "yes")
+
+
+def get_int_param(qs, name, default):
+    """Get a query parameter value and convert it to an integer."""
+    v = get_param(qs, name)
+    try:
+        return int(v) if v is not None else default
+    except ValueError:
+        return default
+
+
+def get_required_param(qs, name) -> str:
+    """Get a single string query parameter or raise MissingParameterError."""
+    v = get_param(qs, name)
+    if v is None:
+        raise MissingParameterError(f"{name} parameter required")
+    return v
+
+
+def get_required_int_param(qs, name) -> int:
+    """Get a query parameter converted to an integer, or raise MissingParameterError."""
+    v = get_param(qs, name)
+    if v is None:
+        raise MissingParameterError(f"{name} parameter required")
+    try:
+        return int(v)
+    except ValueError:
+        raise MissingParameterError(f"{name} parameter must be an integer")
+
+
+def get_paging_params(qs) -> tuple:
+    """Get limit and offset parameters for pagination."""
+    return get_int_param(qs, "limit", 1000), get_int_param(qs, "offset", 0)
+
+
+def build_where_clause(qs, filters) -> tuple:
+    """Build dynamic WHERE conditions and query parameters from a table of filters.
+
+    filters is a list of tuples: (param_name, column_name, filter_type)
+    where filter_type is 'bool', 'str', or 'like'.
+    """
+    conditions = []
+    params = []
+    for param_name, sql_cond, param_type in filters:
+        if param_type == "bool":
+            val = get_bool_param(qs, param_name)
+            if val is not None:
+                conditions.append(sql_cond)
+                params.append(int(val))
+        elif param_type == "str":
+            val = get_param(qs, param_name)
+            if val:
+                conditions.append(sql_cond)
+                params.append(val)
+        elif param_type == "like":
+            val = get_param(qs, param_name)
+            if val:
+                conditions.append(sql_cond)
+                params.append(f"%{val}%")
+        elif param_type == "int":
+            val = get_int_param(qs, param_name, None)
+            if val is not None:
+                conditions.append(sql_cond)
+                params.append(val)
+    return conditions, params
+
+
+class Handler(BaseHTTPRequestHandler):
+    """Custom HTTP request handler for the CScout REST API endpoints."""
+
+    def log_message(self, fmt, *args):
+        """Suppress per-request access log output."""
+        pass
+
+    def send_json(self, data, status=200):
+        """Send a JSON response with CORS headers."""
+        body = json.dumps(data).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def send_error_json(self, status, message):
+        """Send a JSON formatted error response with the specified status code."""
+        self.send_json({"error": message}, status)
+
+    def do_GET(self):
+        """Parse query string parameters and route GET requests to the endpoints."""
+        parsed = urlparse(self.path)
+        path = parsed.path
+        qs = parse_qs(parsed.query)
+
+        conn = get_db()
+
+        try:
+            if path == "/status":
+                self.handle_status(conn, qs)
+            elif path == "/quit":
+                self.handle_quit()
+            elif path == "/identifiers":
+                self.handle_identifiers(conn, qs)
+            elif path == "/identifier":
+                self.handle_identifier(conn, qs)
+            elif path == "/attributes/identifiers":
+                self.handle_attributes_identifiers(conn, qs)
+            elif path == "/attributes/files":
+                self.handle_attributes_files(conn, qs)
+            elif path == "/files":
+                self.handle_files(conn, qs)
+            elif path == "/files/writable":
+                self.handle_files_writable(conn, qs)
+            elif path == "/files/readonly":
+                self.handle_files_readonly(conn, qs)
+            elif path == "/files/with-unused":
+                self.handle_files_with_unused(conn, qs)
+            elif path == "/files/no-statements":
+                self.handle_files_no_statements(conn, qs)
+            elif path == "/files/unprocessed":
+                self.handle_files_unprocessed(conn, qs)
+            elif path == "/files/with-strings":
+                self.handle_files_with_strings(conn, qs)
+            elif path == "/files/h-with-includes":
+                self.handle_files_h_with_includes(conn, qs)
+            elif path == "/filegraph/include":
+                self.handle_filegraph_include(conn, qs)
+            elif path == "/filegraph/compile":
+                self.handle_filegraph_compile(conn, qs)
+            elif path == "/filegraph/control":
+                self.handle_filegraph_control(conn, qs)
+            elif path == "/filegraph/data":
+                self.handle_filegraph_data(conn, qs)
+            elif path == "/filemetrics":
+                self.handle_filemetrics(conn, qs)
+            elif path == "/file/detail":
+                self.handle_file_detail(conn, qs)
+            elif path == "/functions":
+                self.handle_functions(conn, qs)
+            elif path == "/funmetrics":
+                self.handle_funmetrics(conn, qs)
+            elif path == "/callers":
+                self.handle_callers(conn, qs)
+            elif path == "/callees":
+                self.handle_callees(conn, qs)
+            elif path == "/projects":
+                self.handle_projects(conn, qs)
+            elif path == "/refactor/preview":
+                self.handle_refactor_preview(conn, qs)
+            elif path == "/refactor/apply":
+                self.handle_refactor_apply(conn, qs)
+            elif path == "/identifier/detail":
+                self.handle_identifier_detail(conn, qs)
+            elif path == "/filemetrics/aggregate":
+                self.handle_filemetrics_aggregate(conn, qs)
+            elif path == "/funmetrics/aggregate":
+                self.handle_funmetrics_aggregate(conn, qs)
+            elif path == "/project/files":
+                self.handle_project_files(conn, qs)
+            elif path == "/callgraph":
+                self.handle_callgraph(conn, qs)
+            elif path == "/identifiers/counts":
+                self.handle_identifiers_counts(conn, qs)
+            elif path == "/functions/counts":
+                self.handle_functions_counts(conn, qs)
+            elif path == "/functions/byname":
+                self.handle_functions_byname(conn, qs)
+            elif path == "/files/counts":
+                self.handle_files_counts(conn, qs)
+            else:
+                self.send_error_json(404, f"Unknown endpoint: {path}")
+        except MissingParameterError as e:
+            self.send_error_json(400, str(e))
+        except Exception as e:
+            self.send_error_json(500, str(e))
+        finally:
+            conn.close()
+
+    def handle_status(self, conn, qs):
+        """Handle /status requests."""
+        self.send_json({
+            "status": "ok",
+            "indexes_ready": True,
+        })
+
+    def handle_quit(self):
+        """Handle /quit requests to shut down the server gracefully."""
+        self.send_json({"status": "quit"})
+        # Shut down the server in a separate thread to avoid deadlock.
+        threading.Thread(target=self.server.shutdown).start()
+
+    def handle_identifiers(self, conn, qs):
+        """Handle /identifiers requests."""
+        ensure_index(conn, "IDS", ["NAME"])
+        filters = [
+            ("unused", "UNUSED = ?", "bool"),
+            ("macro", "MACRO = ?", "bool"),
+            ("fun", "FUN = ?", "bool"),
+            ("readonly", "READONLY = ?", "bool"),
+            ("lscope", "LSCOPE = ?", "bool"),
+            ("cscope", "CSCOPE = ?", "bool"),
+            ("macroarg", "MACROARG = ?", "bool"),
+            ("ordinary", "ORDINARY = ?", "bool"),
+            ("name", "NAME LIKE ?", "like"),
+        ]
+        conditions, params = build_where_clause(qs, filters)
+
+        if get_bool_param(qs, "file_spanning"):
+            conditions.append(
+                "READONLY = 0"
+                " AND EID IN ("
+                "  SELECT EID FROM TOKENS"
+                "  GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)")
+
+        if get_bool_param(qs, "should_be_static"):
+            conditions.append("READONLY = 0 AND ORDINARY = 1 AND LSCOPE = 1 AND NAME != 'main' AND EID NOT IN (SELECT EID FROM TOKENS GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)")
+
+        limit, offset = get_paging_params(qs)
+
+        where = ("WHERE " + " AND ".join(conditions)
+                 if conditions else "")
+        params += [limit, offset]
+        rows = conn.execute(
+            f"SELECT * FROM IDS {where} LIMIT ? OFFSET ?",
+            params).fetchall()
+        self.send_json(rows_to_list(rows))
+
+    def handle_identifiers_counts(self, conn, qs):
+        """Handle /identifiers/counts — returns COUNT(*) per category in one query.
+
+        This avoids downloading thousands of rows just to show folder counts in
+        the Identifiers sidebar panel.
+        """
+        ensure_index(conn, "TOKENS", ["EID"])
+        # Main counts from IDS (single pass)
+        row = conn.execute("""
+            SELECT
+              COUNT(*) AS all_ids,
+              SUM(CASE WHEN READONLY=1 AND MACROARG=0 THEN 1 ELSE 0 END) AS readonly,
+              SUM(CASE WHEN READONLY=0 AND MACROARG=0 THEN 1 ELSE 0 END) AS writable,
+              SUM(CASE WHEN UNUSED=1 AND LSCOPE=1 AND READONLY=0 AND MACROARG=0 THEN 1 ELSE 0 END) AS unused_project,
+              SUM(CASE WHEN UNUSED=1 AND CSCOPE=1 AND READONLY=0 AND MACROARG=0 THEN 1 ELSE 0 END) AS unused_file,
+              SUM(CASE WHEN UNUSED=1 AND MACRO=1 AND READONLY=0 AND MACROARG=0 THEN 1 ELSE 0 END) AS unused_macros
+            FROM IDS
+        """).fetchone()
+        # File-spanning count (needs TOKENS join)
+        file_spanning = conn.execute("""
+            SELECT COUNT(*) FROM IDS
+            WHERE READONLY=0
+            AND EID IN (SELECT EID FROM TOKENS GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)
+        """).fetchone()[0]
+        # Should-be-static: vars vs funs
+        static_row = conn.execute("""
+            SELECT
+              SUM(CASE WHEN ORDINARY=1 AND FUN=0 THEN 1 ELSE 0 END) AS static_vars,
+              SUM(CASE WHEN FUN=1 THEN 1 ELSE 0 END) AS static_funs
+            FROM IDS
+            WHERE READONLY=0 AND ORDINARY=1 AND LSCOPE=1 AND NAME != 'main'
+            AND EID NOT IN (SELECT EID FROM TOKENS GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)
+        """).fetchone()
+        self.send_json({
+            "all": row["all_ids"],
+            "readonly": row["readonly"],
+            "writable": row["writable"],
+            "file_spanning": file_spanning,
+            "unused_project": row["unused_project"],
+            "unused_file": row["unused_file"],
+            "unused_macros": row["unused_macros"],
+            "static_vars": static_row["static_vars"] or 0,
+            "static_funs": static_row["static_funs"] or 0,
+        })
+
+    def handle_identifier(self, conn, qs):
+        """Handle /identifier requests."""
+        ensure_index(conn, "TOKENS", ["EID"])
+        ensure_index(conn, "LINEPOS", ["FID", "FOFFSET"])
+        eid = get_required_int_param(qs, "eid")
+        row = conn.execute(
+            "SELECT * FROM IDS WHERE EID = ?",
+            (eid,)).fetchone()
+        if row is None:
+            self.send_error_json(404, "Identifier not found")
+            return
+
+        limit, offset = get_paging_params(qs)
+        tokens = conn.execute(
+            """
+            SELECT t.FID, f.NAME AS FILE, t.FOFFSET, l.LNUM, f.RO AS RO
+            FROM TOKENS t
+            JOIN FILES f ON t.FID = f.FID
+            LEFT JOIN LINEPOS l
+                   ON l.FID = t.FID AND l.FOFFSET = (
+                       SELECT MAX(FOFFSET) FROM LINEPOS
+                       WHERE FID = t.FID AND FOFFSET <= t.FOFFSET)
+            WHERE t.EID = ?
+            ORDER BY t.FID, t.FOFFSET
+            LIMIT ? OFFSET ?
+            """,
+            (eid, limit, offset)).fetchall()
+        self.send_json({
+            "identifier": dict(row),
+            "locations": rows_to_list(tokens),
+        })
+
+    def handle_files(self, conn, qs):
+        """Handle /files requests."""
+        rows = conn.execute(
+            "SELECT * FROM FILES ORDER BY NAME").fetchall()
+        self.send_json(rows_to_list(rows))
+
+    def handle_filemetrics(self, conn, qs):
+        """Handle /filemetrics requests."""
+        ensure_index(conn, "FILEMETRICS", ["FID"])
+        fid = get_required_int_param(qs, "fid")
+        rows = conn.execute(
+            "SELECT * FROM FILEMETRICS WHERE FID = ?",
+            (fid,)).fetchall()
+        if not rows:
+            self.send_error_json(404, "File not found")
+            return
+        self.send_json(rows_to_list(rows))
+
+    def handle_file_detail(self, conn, qs):
+        """Handle /file/detail requests.
+        Returns file attributes, metrics, functions defined in it,
+        files it includes, and files that include it.
+        """
+        fid = get_required_int_param(qs, "fid")
+        file_row = conn.execute(
+            "SELECT * FROM FILES WHERE FID = ?",
+            (fid,)).fetchone()
+        if file_row is None:
+            self.send_error_json(404, "File not found")
+            return
+        metrics = conn.execute(
+            "SELECT * FROM FILEMETRICS WHERE FID = ? AND PRECPP = 0",
+            (fid,)).fetchone()
+        functions = conn.execute(
+            """SELECT f.ID, f.NAME, f.FANIN, fm.FANOUT, fm.CCYCL1,
+                      lp.LNUM
+               FROM FUNCTIONS f
+               LEFT JOIN FUNCTIONMETRICS fm
+                      ON fm.FUNCTIONID = f.ID AND fm.PRECPP = 0
+               LEFT JOIN LINEPOS lp
+                      ON lp.FID = f.FID AND lp.FOFFSET = (
+                          SELECT MAX(FOFFSET) FROM LINEPOS
+                          WHERE FID = f.FID AND FOFFSET <= f.FOFFSET)
+               WHERE f.FID = ? AND f.DEFINED = 1
+               ORDER BY lp.LNUM""",
+            (fid,)).fetchall()
+        includes = conn.execute(
+            """SELECT DISTINCT f.FID, f.NAME, f.RO
+               FROM INCLUDERS i
+               JOIN FILES f ON i.BASEFILEID = f.FID
+               WHERE i.INCLUDERID = ?
+               ORDER BY f.NAME""",
+            (fid,)).fetchall()
+        included_by = conn.execute(
+            """SELECT DISTINCT f.FID, f.NAME, f.RO
+               FROM INCLUDERS i
+               JOIN FILES f ON i.INCLUDERID = f.FID
+               WHERE i.BASEFILEID = ?
+               ORDER BY f.NAME""",
+            (fid,)).fetchall()
+        self.send_json({
+            "file": dict(file_row),
+            "metrics": dict(metrics) if metrics else {},
+            "functions": rows_to_list(functions),
+            "includes": rows_to_list(includes),
+            "included_by": rows_to_list(included_by),
+        })
+
+    def handle_functions(self, conn, qs):
+        """Handle /functions requests."""
+        ensure_index(conn, "LINEPOS", ["FID", "FOFFSET"])
+        filters = [
+            ("defined", "DEFINED = ?", "bool"),
+            ("filescoped", "FILESCOPED = ?", "bool"),
+            ("ismacro", "f.ISMACRO = ?", "bool"),
+            ("fanin", "f.FANIN = ?", "int"),
+            ("max_fanin", "f.FANIN <= ?", "int"),
+        ]
+        conditions, params = build_where_clause(qs, filters)
+
+        limit, offset = get_paging_params(qs)
+
+        where = ("WHERE " + " AND ".join(conditions)
+                 if conditions else "")
+        params += [limit, offset]
+        rows = conn.execute(
+            f"""SELECT f.ID, f.NAME, f.ISMACRO, f.DEFINED, f.DECLARED,
+                      f.FILESCOPED, f.FID, f.FOFFSET, f.FANIN,
+                      fm.FANOUT, fm.CCYCL1, fi.NAME AS FILE, l.LNUM
+               FROM FUNCTIONS f
+               LEFT JOIN FUNCTIONMETRICS fm
+                      ON fm.FUNCTIONID = f.ID AND fm.PRECPP = 0
+               LEFT JOIN FILES fi ON fi.FID = f.FID
+               LEFT JOIN LINEPOS l
+                      ON l.FID = f.FID AND l.FOFFSET = (
+                          SELECT MAX(FOFFSET) FROM LINEPOS
+                          WHERE FID = f.FID AND FOFFSET <= f.FOFFSET)
+               {where} LIMIT ? OFFSET ?""",
+            params).fetchall()
+        self.send_json(rows_to_list(rows))
+
+    def handle_functions_counts(self, conn, qs):
+        """Handle /functions/counts — returns COUNT(*) per sidebar category.
+
+        Single SQL query using CASE WHEN to avoid multiple round-trips.
+        Only counts DEFINED=1 functions (matching what the sidebar shows).
+        """
+        row = conn.execute("""
+            SELECT
+              COUNT(*) AS all_fns,
+              SUM(CASE WHEN FILESCOPED=0 AND ISMACRO=0 THEN 1 ELSE 0 END) AS project_scoped,
+              SUM(CASE WHEN FILESCOPED=1 AND ISMACRO=0 THEN 1 ELSE 0 END) AS file_scoped,
+              SUM(CASE WHEN FANIN=0 AND ISMACRO=0 THEN 1 ELSE 0 END) AS not_called,
+              SUM(CASE WHEN FANIN=1 AND ISMACRO=0 THEN 1 ELSE 0 END) AS called_once
+            FROM FUNCTIONS
+            WHERE DEFINED=1
+        """).fetchone()
+        self.send_json({
+            "all": row["all_fns"],
+            "project_scoped": row["project_scoped"],
+            "file_scoped": row["file_scoped"],
+            "not_called": row["not_called"],
+            "called_once": row["called_once"],
+        })
+
+    def handle_functions_byname(self, conn, qs):
+        """Handle /functions/byname — return a single function row by name.
+
+        Used by the hover provider to fetch complexity metrics for one function
+        without downloading the entire function list (which was 10,000+ rows).
+        Returns the first matching defined function with its metrics.
+        """
+        ensure_index(conn, "LINEPOS", ["FID", "FOFFSET"])
+        name = get_required_param(qs, "name")
+        row = conn.execute(
+            """SELECT f.ID, f.NAME, f.ISMACRO, f.DEFINED, f.DECLARED, f.FILESCOPED,
+                      f.FID, f.FOFFSET, f.FANIN, fm.FANOUT, fm.CCYCL1,
+                      fi.NAME AS FILE, l.LNUM
+               FROM FUNCTIONS f
+               LEFT JOIN FUNCTIONMETRICS fm ON fm.FUNCTIONID = f.ID AND fm.PRECPP = 0
+               LEFT JOIN FILES fi ON fi.FID = f.FID
+               LEFT JOIN LINEPOS l ON l.FID = f.FID AND l.FOFFSET = (
+                   SELECT MAX(FOFFSET) FROM LINEPOS WHERE FID = f.FID AND FOFFSET <= f.FOFFSET)
+               WHERE f.NAME = ? AND f.DEFINED = 1
+               LIMIT 1""",
+            (name,)).fetchone()
+        if row is None:
+            self.send_json(None)
+        else:
+            self.send_json(dict(row))
+
+    def handle_files_counts(self, conn, qs):
+        """Handle /files/counts — returns COUNT(*) per file sidebar category.
+
+        Replaces 8 separate API calls at panel open with one SQL query.
+        """
+        row = conn.execute("""
+            SELECT
+              COUNT(*) AS all_files,
+              SUM(CASE WHEN RO=1 THEN 1 ELSE 0 END) AS readonly,
+              SUM(CASE WHEN RO=0 THEN 1 ELSE 0 END) AS writable
+            FROM FILES
+        """).fetchone()
+        with_unused = conn.execute("""
+            SELECT COUNT(DISTINCT f.FID) FROM FILES f
+            JOIN TOKENS t ON t.FID = f.FID
+            JOIN IDS i ON i.EID = t.EID
+            WHERE f.RO=0 AND i.UNUSED=1 AND i.READONLY=0
+        """).fetchone()[0]
+        no_stmts = conn.execute("""
+            SELECT COUNT(*) FROM FILES f
+            JOIN FILEMETRICS fm ON fm.FID = f.FID
+            WHERE f.RO=0 AND f.NAME LIKE '%.c' AND fm.PRECPP=0
+            AND (fm.NSTMT=0 OR fm.NSTMT IS NULL)
+        """).fetchone()[0]
+        unprocessed = conn.execute("""
+            SELECT COUNT(*) FROM FILES f
+            JOIN FILEMETRICS fm ON fm.FID = f.FID
+            WHERE f.RO=0 AND fm.PRECPP=0 AND fm.NULINE > 0
+        """).fetchone()[0]
+        with_strings = conn.execute("""
+            SELECT COUNT(*) FROM FILES f
+            JOIN FILEMETRICS fm ON fm.FID = f.FID
+            WHERE f.RO=0 AND fm.PRECPP=0 AND fm.NSTRING > 0
+        """).fetchone()[0]
+        h_with_includes = conn.execute("""
+            SELECT COUNT(DISTINCT f.FID) FROM FILES f
+            JOIN INCLUDERS i ON i.INCLUDERID = f.FID
+            WHERE f.RO=0 AND f.NAME LIKE '%.h'
+        """).fetchone()[0]
+        self.send_json({
+            "all": row["all_files"],
+            "readonly": row["readonly"],
+            "writable": row["writable"],
+            "with_unused": with_unused,
+            "no_statements": no_stmts,
+            "unprocessed": unprocessed,
+            "with_strings": with_strings,
+            "h_with_includes": h_with_includes,
+        })
+
+    def handle_funmetrics(self, conn, qs):
+        """Handle /funmetrics requests."""
+        ensure_index(conn, "FUNCTIONMETRICS", ["FUNCTIONID"])
+        fnid = get_required_int_param(qs, "fnid")
+        rows = conn.execute(
+            "SELECT * FROM FUNCTIONMETRICS WHERE FUNCTIONID = ?",
+            (fnid,)).fetchall()
+        if not rows:
+            self.send_error_json(404, "Function not found")
+            return
+        self.send_json(rows_to_list(rows))
+
+    def handle_callers(self, conn, qs):
+        """Handle /callers requests."""
+        ensure_index(conn, "FCALLS", ["DESTID"])
+        fnid = get_required_int_param(qs, "fnid")
+        rows = conn.execute(
+            """
+            SELECT f.ID, f.NAME, f.FID, f.FOFFSET,
+                   fi.NAME AS FILE
+            FROM FCALLS fc
+            JOIN FUNCTIONS f ON fc.SOURCEID = f.ID
+            JOIN FILES fi ON f.FID = fi.FID
+            WHERE fc.DESTID = ?
+            ORDER BY f.NAME
+            """,
+            (fnid,)).fetchall()
+        self.send_json(rows_to_list(rows))
+
+    def handle_callees(self, conn, qs):
+        """Handle /callees requests."""
+        ensure_index(conn, "FCALLS", ["SOURCEID"])
+        fnid = get_required_int_param(qs, "fnid")
+        rows = conn.execute(
+            """
+            SELECT f.ID, f.NAME, f.FID, f.FOFFSET,
+                   fi.NAME AS FILE
+            FROM FCALLS fc
+            JOIN FUNCTIONS f ON fc.DESTID = f.ID
+            JOIN FILES fi ON f.FID = fi.FID
+            WHERE fc.SOURCEID = ?
+            ORDER BY f.NAME
+            """,
+            (fnid,)).fetchall()
+        self.send_json(rows_to_list(rows))
+
+    def handle_projects(self, conn, qs):
+        """Handle /projects requests."""
+        rows = conn.execute(
+            "SELECT * FROM PROJECTS").fetchall()
+        self.send_json(rows_to_list(rows))
+
+    def handle_refactor_preview(self, conn, qs):
+        """Handle /refactor/preview requests."""
+        ensure_index(conn, "TOKENS", ["EID"])
+        ensure_index(conn, "LINEPOS", ["FID", "FOFFSET"])
+        eid = get_required_int_param(qs, "eid")
+        newname = get_required_param(qs, "newname")
+        id_row = conn.execute(
+            "SELECT NAME FROM IDS WHERE EID = ?",
+            (eid,)).fetchone()
+        if id_row is None:
+            self.send_error_json(404, "Identifier not found")
+            return
+        tokens = conn.execute(
+            """
+            SELECT t.FID, f.NAME AS FILE, t.FOFFSET, l.LNUM, l.FOFFSET AS LINE_START_OFFSET, f.RO AS RO
+            FROM TOKENS t
+            JOIN FILES f ON t.FID = f.FID
+            LEFT JOIN LINEPOS l
+                   ON l.FID = t.FID AND l.FOFFSET = (
+                       SELECT MAX(FOFFSET) FROM LINEPOS
+                       WHERE FID = t.FID AND FOFFSET <= t.FOFFSET)
+            WHERE t.EID = ? AND f.RO = 0
+            ORDER BY t.FID, t.FOFFSET
+            """,
+            (eid,)).fetchall()
+        self.send_json({
+            "eid": eid,
+            "old_name": id_row["NAME"],
+            "new_name": newname,
+            "total_replacements": len(tokens),
+            "locations": rows_to_list(tokens),
+        })
+
+    def handle_identifier_detail(self, conn, qs):
+        """Handle /identifier/detail requests.
+
+        Returns full identifier attributes, occurrence count, projects,
+        dependent files, associated functions, and function detail.
+        """
+        eid = get_required_int_param(qs, "eid")
+        id_row = conn.execute(
+            "SELECT * FROM IDS WHERE EID = ?",
+            (eid,)).fetchone()
+        if id_row is None:
+            self.send_error_json(404, "Identifier not found")
+            return
+
+        projects = conn.execute(
+            """SELECT p.PID, p.NAME FROM IDPROJ ip
+               JOIN PROJECTS p ON ip.PID = p.PID
+               WHERE ip.EID = ?""",
+            (eid,)).fetchall()
+
+        occ = conn.execute(
+            "SELECT COUNT(*) AS CNT FROM TOKENS WHERE EID = ?",
+            (eid,)).fetchone()
+
+        dep_files = conn.execute(
+            """SELECT DISTINCT f.FID, f.NAME, f.RO
+               FROM TOKENS t JOIN FILES f ON t.FID = f.FID
+               WHERE t.EID = ?
+               ORDER BY f.NAME""",
+            (eid,)).fetchall()
+
+        # Functions whose name contains this identifier.
+        assoc_fns = conn.execute(
+            """SELECT DISTINCT fn.ID, fn.NAME,
+                      fi_f.NAME AS FILE, fn.FOFFSET
+               FROM FUNCTIONID fi
+               JOIN FUNCTIONS fn ON fi.FUNCTIONID = fn.ID
+               JOIN FILES fi_f ON fn.FID = fi_f.FID
+               WHERE fi.FID IN (
+                   SELECT FID FROM TOKENS WHERE EID = ?)
+               ORDER BY fn.NAME""",
+            (eid,)).fetchall()
+
+        fn_detail = None
+        if id_row["FUN"]:
+            fn_row = conn.execute(
+                "SELECT * FROM FUNCTIONS WHERE NAME = ?",
+                (id_row["NAME"],)).fetchone()
+            if fn_row:
+                fn_id = fn_row["ID"]
+                callers_count = conn.execute(
+                    "SELECT COUNT(*) AS CNT FROM FCALLS WHERE DESTID = ?",
+                    (fn_id,)).fetchone()["CNT"]
+                callees_count = conn.execute(
+                    "SELECT COUNT(*) AS CNT FROM FCALLS WHERE SOURCEID = ?",
+                    (fn_id,)).fetchone()["CNT"]
+                fn_def = conn.execute(
+                    """SELECT fd.*, f.NAME AS FILE
+                       FROM FUNCTIONDEFS fd
+                       JOIN FILES f ON fd.FIDBEGIN = f.FID
+                       WHERE fd.FUNCTIONID = ?""",
+                    (fn_id,)).fetchone()
+                fn_metrics = conn.execute(
+                    "SELECT * FROM FUNCTIONMETRICS WHERE FUNCTIONID = ?",
+                    (fn_id,)).fetchall()
+                fn_detail = {
+                    "function": dict(fn_row),
+                    "callers_count": callers_count,
+                    "callees_count": callees_count,
+                    "definition": dict(fn_def) if fn_def else None,
+                    "metrics": rows_to_list(fn_metrics),
+                }
+
+        locations = conn.execute(
+            """SELECT t.FOFFSET, t.EID, f.FID, f.NAME AS FILE, f.RO,
+                      (SELECT lp.LNUM FROM LINEPOS lp
+                       WHERE lp.FID = t.FID AND lp.FOFFSET <= t.FOFFSET
+                       ORDER BY lp.FOFFSET DESC LIMIT 1) AS LNUM
+               FROM TOKENS t
+               JOIN FILES f ON t.FID = f.FID
+               WHERE t.EID = ?
+               ORDER BY f.NAME, LNUM""",
+            (eid,)).fetchall()
+        self.send_json({
+            "identifier": dict(id_row),
+            "occurrences": occ["CNT"] if occ else 0,
+            "locations": rows_to_list(locations),
+            "projects": rows_to_list(projects),
+            "dependent_files": rows_to_list(dep_files),
+            "associated_functions": rows_to_list(assoc_fns),
+            "function_detail": fn_detail,
+        })
+
+    def handle_attributes_identifiers(self, conn, qs):
+        """Return identifier attribute names and DB column ids.
+        Read from METADATA table if available, otherwise use built-in defaults.
+        """
+        try:
+            row = conn.execute(
+                "SELECT VALUE FROM METADATA WHERE KEY = 'IdentifierAttributes'"
+            ).fetchone()
+            if row:
+                names = row["VALUE"].split(',')
+                # Map names to DB column ids, in the same order as the METADATA value
+                ids = ["WRITABLE", "READONLY", "SUETAG", "SUMEMBER", "LABEL", "ORDINARY",
+                       "MACRO", "UNDEFMACRO", "MACROARG", "CSCOPE", "LSCOPE",
+                       "TYPEDEF", "ENUM", "YACC", "FUN", "UNUSED", "XFILE"]
+                result = [{"id": ids[i], "name": names[i]}
+                          for i in range(min(len(ids), len(names)))]
+                self.send_json(result)
+                return
+        except Exception:
+            pass
+        # Fallback to hardcoded list
+        self.send_json([
+            {"id": "WRITABLE",   "name": "Writable"},
+            {"id": "READONLY",   "name": "Read-only"},
+            {"id": "ORDINARY",   "name": "Ordinary identifier"},
+            {"id": "MACRO",      "name": "Macro"},
+            {"id": "FUNMACRO",   "name": "Function-like macro"},
+            {"id": "UNDEFMACRO", "name": "Undefined macro"},
+            {"id": "MACROARG",   "name": "Macro argument"},
+            {"id": "SUETAG",     "name": "Tag for struct/union/enum"},
+            {"id": "SUMEMBER",   "name": "Member of struct/union"},
+            {"id": "LABEL",      "name": "Label"},
+            {"id": "TYPEDEF",    "name": "Typedef"},
+            {"id": "ENUM",       "name": "Enumeration constant"},
+            {"id": "YACC",       "name": "Yacc identifier"},
+            {"id": "FUN",        "name": "Function"},
+            {"id": "CSCOPE",     "name": "File scope"},
+            {"id": "LSCOPE",     "name": "Project scope"},
+            {"id": "UNUSED",     "name": "Unused"},
+            {"id": "XFILE",      "name": "Crosses file boundary"},
+        ])
+
+    def handle_attributes_files(self, conn, qs):
+        """Return file metric names and DB column ids.
+        Read from METADATA table if available, otherwise use built-in defaults.
+        """
+        try:
+            row = conn.execute(
+                "SELECT VALUE FROM METADATA WHERE KEY = 'FileMetricFields'"
+            ).fetchone()
+            if row:
+                names = row["VALUE"].split(',')
+                ids = ["NCHAR","NCCOMMENT","NSPACE","NLCOMMENT","NBCOMMENT",
+                       "NLINE","MAXLINELEN","MAXSTMTLEN","MAXSTMTNEST",
+                       "MAXBRACENEST","MAXBRACKNEST","BRACENEST","BRACKNEST",
+                       "NULINE","NPPDIRECTIVE","NPPCOND","NPPFMACRO","NPPOMACRO",
+                       "NTOKEN","NSTMT","NOP","NUOP","NNCONST","NCLIT","NSTRING",
+                       "NPPCONCATOP","NPPSTRINGOP","NIF","NELSE","NSWITCH","NCASE",
+                       "NDEFAULT","NBREAK","NFOR","NWHILE","NDO","NCONTINUE",
+                       "NGOTO","NRETURN","NASM","NTYPEOF","NPID","NFID","NMID",
+                       "NID","NUPID","NUFID","NUMID","NUID","NLABEL",
+                       "NMACROEXPANDTOKEN"]
+                result = [{"id": ids[i], "name": names[i]}
+                          for i in range(min(len(ids), len(names)))]
+                self.send_json(result)
+                return
+        except Exception:
+            pass
+        self.send_json([
+            {"id": "NCHAR",             "name": "Number of characters"},
+            {"id": "NCCOMMENT",         "name": "Number of comment characters"},
+            {"id": "NSPACE",            "name": "Number of space characters"},
+            {"id": "NLCOMMENT",         "name": "Number of line comments"},
+            {"id": "NBCOMMENT",         "name": "Number of block comments"},
+            {"id": "NLINE",             "name": "Number of lines"},
+            {"id": "MAXLINELEN",        "name": "Maximum number of characters in a line"},
+            {"id": "MAXSTMTLEN",        "name": "Maximum number of tokens in a statement"},
+            {"id": "MAXSTMTNEST",       "name": "Maximum level of statement nesting"},
+            {"id": "MAXBRACENEST",      "name": "Maximum level of brace nesting"},
+            {"id": "MAXBRACKNEST",      "name": "Maximum level of bracket nesting"},
+            {"id": "BRACENEST",         "name": "Dangling brace nesting"},
+            {"id": "BRACKNEST",         "name": "Dangling bracket nesting"},
+            {"id": "NULINE",            "name": "Number of unprocessed lines"},
+            {"id": "NTOKEN",            "name": "Number of tokens"},
+            {"id": "NPPDIRECTIVE",      "name": "Number of C preprocessor directives"},
+            {"id": "NPPCOND",           "name": "Number of processed C preprocessor conditionals (ifdef, if, elif)"},
+            {"id": "NPPFMACRO",         "name": "Number of defined C preprocessor function-like macros"},
+            {"id": "NPPOMACRO",         "name": "Number of defined C preprocessor object-like macros"},
+            {"id": "NPPCONCATOP",       "name": "Number of token concatenation operators (##)"},
+            {"id": "NPPSTRINGOP",       "name": "Number of token stringification operators (#)"},
+            {"id": "NSTMT",             "name": "Number of statements or declarations"},
+            {"id": "NOP",               "name": "Number of operators"},
+            {"id": "NUOP",              "name": "Number of unique operators"},
+            {"id": "NNCONST",           "name": "Number of numeric constants"},
+            {"id": "NCLIT",             "name": "Number of character literals"},
+            {"id": "NSTRING",           "name": "Number of character strings"},
+            {"id": "NIF",               "name": "Number of if statements"},
+            {"id": "NELSE",             "name": "Number of else clauses"},
+            {"id": "NSWITCH",           "name": "Number of switch statements"},
+            {"id": "NCASE",             "name": "Number of case labels"},
+            {"id": "NDEFAULT",          "name": "Number of default labels"},
+            {"id": "NBREAK",            "name": "Number of break statements"},
+            {"id": "NFOR",              "name": "Number of for statements"},
+            {"id": "NWHILE",            "name": "Number of while statements"},
+            {"id": "NDO",               "name": "Number of do statements"},
+            {"id": "NCONTINUE",         "name": "Number of continue statements"},
+            {"id": "NGOTO",             "name": "Number of goto statements"},
+            {"id": "NRETURN",           "name": "Number of return statements"},
+            {"id": "NASM",              "name": "Number of assembly statements"},
+            {"id": "NTYPEOF",           "name": "Number of typeof operators"},
+            {"id": "NPID",              "name": "Number of project-scope identifiers"},
+            {"id": "NFID",              "name": "Number of file-scope (static) identifiers"},
+            {"id": "NMID",              "name": "Number of macro identifiers"},
+            {"id": "NID",               "name": "Total number of object and object-like identifiers"},
+            {"id": "NUPID",             "name": "Number of unique project-scope identifiers"},
+            {"id": "NUFID",             "name": "Number of unique file-scope (static) identifiers"},
+            {"id": "NUMID",             "name": "Number of unique macro identifiers"},
+            {"id": "NUID",              "name": "Number of unique object and object-like identifiers"},
+            {"id": "NLABEL",            "name": "Number of goto labels"},
+            {"id": "NMACROEXPANDTOKEN", "name": "Tokens added by macro expansion"},
+        ])
+
+    def handle_filemetrics_aggregate(self, conn, qs):
+        """Handle /filemetrics/aggregate requests.
+
+        Returns all file metrics rows for aggregate analysis.
+        """
+        rows = conn.execute("SELECT * FROM FILEMETRICS").fetchall()
+        self.send_json(rows_to_list(rows))
+
+    def handle_funmetrics_aggregate(self, conn, qs):
+        """Handle /funmetrics/aggregate requests.
+
+        Returns all function metrics rows for aggregate analysis.
+        """
+        rows = conn.execute("SELECT * FROM FUNCTIONMETRICS").fetchall()
+        self.send_json(rows_to_list(rows))
+
+    def handle_project_files(self, conn, qs):
+        """Handle /project/files requests.
+
+        Returns all files belonging to a specific project.
+        """
+        pid = get_required_int_param(qs, "pid")
+        rows = conn.execute(
+            """SELECT f.FID, f.NAME, f.RO
+               FROM FILEPROJ fp
+               JOIN FILES f ON fp.FID = f.FID
+               WHERE fp.PID = ?
+               ORDER BY f.NAME""",
+            (pid,)).fetchall()
+        self.send_json(rows_to_list(rows))
+
+    def handle_callgraph(self, conn, qs):
+        """Handle /callgraph requests.
+
+        Generates a call graph SVG for a function using graphviz dot.
+        Returns the SVG as text/html for display in a webview.
+        """
+
+        fnid = get_required_int_param(qs, "fnid")
+        fn_row = conn.execute(
+            "SELECT NAME FROM FUNCTIONS WHERE ID = ?",
+            (fnid,)).fetchone()
+        if fn_row is None:
+            self.send_error_json(404, "Function not found")
+            return
+
+        fn_name = fn_row["NAME"]
+
+        callers = conn.execute(
+            """SELECT f.ID, f.NAME FROM FCALLS fc
+            JOIN FUNCTIONS f ON fc.SOURCEID = f.ID
+            WHERE fc.DESTID = ?""",
+            (fnid,)).fetchall()
+        callees = conn.execute(
+            """SELECT f.ID, f.NAME FROM FCALLS fc
+            JOIN FUNCTIONS f ON fc.DESTID = f.ID
+            WHERE fc.SOURCEID = ?""",
+            (fnid,)).fetchall()
+
+        dot_lines = [
+            "digraph callgraph {",
+            '\trankdir=LR;',
+            '\tgraph [bgcolor=transparent];',
+            '\tnode [shape=box, fontname="Helvetica", fontsize=10, style=filled, fillcolor="#4a4080", fontcolor="#ffffff"];',
+            '\tedge [fontsize=9, color="#aaaaaa", arrowsize=0.8];',
+            f'\t"{fn_name}" [fillcolor="#4a9eda", fontcolor=white, penwidth=2];',
+        ]
+
+        for c in callers:
+            dot_lines.append(f'\t"{c["NAME"]}" [fillcolor="#4a4080", fontcolor=white];')
+            dot_lines.append(f'\t"{c["NAME"]}" -> "{fn_name}";')
+        for c in callees:
+            dot_lines.append(f'\t"{c["NAME"]}" [fillcolor="#2d6b5e", fontcolor=white];')
+            dot_lines.append(f'\t"{fn_name}" -> "{c["NAME"]}";')
+
+        dot_lines.append("}")
+        dot_source = "\n".join(dot_lines)
+
+        try:
+            result = subprocess.run(
+                ["dot", "-Tsvg"],
+                input=dot_source.encode("utf-8"),
+                capture_output=True,
+                timeout=10
+            )
+            if result.returncode != 0:
+                self.send_error_json(500,
+                    f"graphviz error: {result.stderr.decode()}")
+                return
+            svg = result.stdout.decode("utf-8")
+        except FileNotFoundError:
+            self.send_error_json(500,
+                "graphviz not found. Install with: apt install graphviz")
+            return
+        except subprocess.TimeoutExpired:
+            self.send_error_json(500, "graphviz timed out")
+            return
+
+        html = f"""<!doctype html>
+    <html><head><meta charset="utf-8">
+    <style>
+    body {{ margin: 0; background: #1e1e1e; display: flex;
+        align-items: center; justify-content: center; min-height: 100vh; }}
+    svg {{ max-width: 100%; height: auto; }}
+    </style>
+    </head><body>{svg}</body></html>"""
+
+        body = html.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def handle_refactor_apply(self, conn, qs):
+        """Handle /refactor/apply requests.
+
+        Performs byte-precise rename using token offsets from the DB.
+        Modifies source files on disk. Only modifies writable files.
+        Applies replacements from end to start within each file so
+        earlier offsets are not shifted by the replacement.
+        """
+        eid = get_required_int_param(qs, "eid")
+        newname = get_required_param(qs, "newname")
+        id_row = conn.execute(
+            "SELECT NAME FROM IDS WHERE EID = ?",
+            (eid,)).fetchone()
+        if id_row is None:
+            self.send_error_json(404, "Identifier not found")
+            return
+
+        old_name = id_row["NAME"]
+        old_len = len(old_name.encode("utf-8"))
+        new_bytes = newname.encode("utf-8")
+
+        tokens = conn.execute(
+            """SELECT t.FID, f.NAME AS FILE, t.FOFFSET
+               FROM TOKENS t
+               JOIN FILES f ON t.FID = f.FID
+               WHERE t.EID = ? AND f.RO = 0
+               ORDER BY t.FID, t.FOFFSET DESC""",
+            (eid,)).fetchall()
+
+        by_file = {}
+        for tok in tokens:
+            fid = tok["FID"]
+            if fid not in by_file:
+                by_file[fid] = {"path": tok["FILE"], "offsets": []}
+            by_file[fid]["offsets"].append(tok["FOFFSET"])
+
+        modified_files = []
+        for fid, info in by_file.items():
+            fpath = info["path"]
+            try:
+                with open(fpath, "rb") as fh:
+                    data = bytearray(fh.read())
+                for offset in sorted(info["offsets"], reverse=True):
+                    data[offset:offset + old_len] = new_bytes
+                with open(fpath, "wb") as fh:
+                    fh.write(data)
+                modified_files.append(fpath)
+            except OSError as e:
+                self.send_error_json(
+                    500, f"Failed to modify {fpath}: {e}")
+                return
+
+        self.send_json({
+            "old_name": old_name,
+            "new_name": newname,
+            "modified_files": modified_files,
+            "total_replacements": len(tokens),
+        })
+
+    def handle_files_writable(self, conn, qs):
+        """Writable files — RO=0."""
+        rows = conn.execute(
+            "SELECT * FROM FILES WHERE RO = 0 ORDER BY NAME"
+        ).fetchall()
+        self.send_json(rows_to_list(rows))
+
+    def handle_files_readonly(self, conn, qs):
+        """Read-only files — RO=1."""
+        rows = conn.execute(
+            "SELECT * FROM FILES WHERE RO = 1 ORDER BY NAME"
+        ).fetchall()
+        self.send_json(rows_to_list(rows))
+
+    def handle_files_with_unused(self, conn, qs):
+        """Writable files containing unused writable identifiers."""
+        rows = conn.execute(
+            """SELECT DISTINCT f.FID, f.NAME, f.RO
+            FROM FILES f
+            JOIN TOKENS t ON t.FID = f.FID
+            JOIN IDS i ON i.EID = t.EID
+            WHERE f.RO = 0
+                AND i.UNUSED = 1
+                AND i.READONLY = 0
+            ORDER BY f.NAME"""
+        ).fetchall()
+        self.send_json(rows_to_list(rows))
+
+    def handle_files_no_statements(self, conn, qs):
+        """Writable .c files without any statements (NSTMT=0, post-cpp)."""
+        rows = conn.execute(
+            """SELECT f.FID, f.NAME, f.RO
+            FROM FILES f
+            JOIN FILEMETRICS fm ON fm.FID = f.FID
+            WHERE f.RO = 0
+                AND f.NAME LIKE '%.c'
+                AND fm.PRECPP = 0
+                AND (fm.NSTMT = 0 OR fm.NSTMT IS NULL)
+            ORDER BY f.NAME"""
+        ).fetchall()
+        self.send_json(rows_to_list(rows))
+
+    def handle_files_unprocessed(self, conn, qs):
+        """Writable files containing unprocessed lines."""
+        rows = conn.execute(
+            """SELECT f.FID, f.NAME, f.RO
+            FROM FILES f
+            JOIN FILEMETRICS fm ON fm.FID = f.FID
+            WHERE f.RO = 0
+                AND fm.PRECPP = 0
+                AND fm.NULINE > 0
+            ORDER BY f.NAME"""
+        ).fetchall()
+        self.send_json(rows_to_list(rows))
+
+    def handle_files_with_strings(self, conn, qs):
+        """Writable files containing string literals."""
+        rows = conn.execute(
+            """SELECT f.FID, f.NAME, f.RO
+            FROM FILES f
+            JOIN FILEMETRICS fm ON fm.FID = f.FID
+            WHERE f.RO = 0
+                AND fm.PRECPP = 0
+                AND fm.NSTRING > 0
+            ORDER BY f.NAME"""
+        ).fetchall()
+        self.send_json(rows_to_list(rows))
+
+    def handle_files_h_with_includes(self, conn, qs):
+        """Writable .h files with #include directives."""
+        rows = conn.execute(
+            """SELECT f.FID, f.NAME, f.RO
+            FROM FILES f
+            JOIN FILEMETRICS fm ON fm.FID = f.FID
+            WHERE f.RO = 0
+                AND f.NAME LIKE '%.h'
+                AND fm.PRECPP = 1
+                AND fm.NINCFILE > 0
+            ORDER BY f.NAME"""
+        ).fetchall()
+        self.send_json(rows_to_list(rows))
+
+    def handle_filegraph_include(self, conn, qs):
+        """File include graph via graphviz."""
+        writable_only = get_bool_param(qs, "writable")
+        if writable_only:
+            rows = conn.execute("""
+                SELECT DISTINCT f1.NAME AS SRC, f2.NAME AS DST
+                FROM INCLUDERS i
+                JOIN FILES f1 ON i.BASEFILEID = f1.FID
+                JOIN FILES f2 ON i.INCLUDERID = f2.FID
+                WHERE f1.RO = 0 AND f2.RO = 0
+                AND f2.NAME NOT LIKE '%.cs'
+            """).fetchall()
+        else:
+            rows = conn.execute("""
+                SELECT DISTINCT f1.NAME AS SRC, f2.NAME AS DST
+                FROM INCLUDERS i
+                JOIN FILES f1 ON i.BASEFILEID = f1.FID
+                JOIN FILES f2 ON i.INCLUDERID = f2.FID
+                WHERE f2.NAME NOT LIKE '%.cs'
+            """).fetchall()
+        self._send_file_graph_svg(rows, "File include graph")
+
+    def handle_filegraph_compile(self, conn, qs):
+        """Compile-time dependency graph via graphviz."""
+        writable_only = get_bool_param(qs, "writable")
+        if writable_only:
+            rows = conn.execute("""
+                SELECT DISTINCT f1.NAME AS SRC, f2.NAME AS DST
+                FROM DEFINERS d
+                JOIN FILES f1 ON d.BASEFILEID = f1.FID
+                JOIN FILES f2 ON d.DEFINERID = f2.FID
+                WHERE f1.RO = 0
+            """).fetchall()
+        else:
+            rows = conn.execute("""
+                SELECT DISTINCT f1.NAME AS SRC, f2.NAME AS DST
+                FROM DEFINERS d
+                JOIN FILES f1 ON d.BASEFILEID = f1.FID
+                JOIN FILES f2 ON d.DEFINERID = f2.FID
+            """).fetchall()
+        self._send_file_graph_svg(rows, "Compile-time dependency graph")
+
+    def handle_filegraph_control(self, conn, qs):
+        """Control dependency graph (through function calls) via graphviz."""
+        writable_only = get_bool_param(qs, "writable")
+        if writable_only:
+            rows = conn.execute("""
+                SELECT DISTINCT f1.NAME AS SRC, f2.NAME AS DST
+                FROM FCALLS fc
+                JOIN FUNCTIONS fn1 ON fc.SOURCEID = fn1.ID
+                JOIN FUNCTIONS fn2 ON fc.DESTID = fn2.ID
+                JOIN FILES f1 ON fn1.FID = f1.FID
+                JOIN FILES f2 ON fn2.FID = f2.FID
+                WHERE f1.FID != f2.FID AND f1.RO = 0 AND f2.RO = 0
+            """).fetchall()
+        else:
+            rows = conn.execute("""
+                SELECT DISTINCT f1.NAME AS SRC, f2.NAME AS DST
+                FROM FCALLS fc
+                JOIN FUNCTIONS fn1 ON fc.SOURCEID = fn1.ID
+                JOIN FUNCTIONS fn2 ON fc.DESTID = fn2.ID
+                JOIN FILES f1 ON fn1.FID = f1.FID
+                JOIN FILES f2 ON fn2.FID = f2.FID
+                WHERE f1.FID != f2.FID
+            """).fetchall()
+        self._send_file_graph_svg(rows, "Control dependency graph")
+
+    def handle_filegraph_data(self, conn, qs):
+        """Data dependency graph (through global variables) via graphviz."""
+        writable_only = get_bool_param(qs, "writable")
+        if writable_only:
+            rows = conn.execute("""
+                SELECT DISTINCT f1.NAME AS SRC, f2.NAME AS DST
+                FROM TOKENS t1
+                JOIN TOKENS t2 ON t1.EID = t2.EID AND t1.FID != t2.FID
+                JOIN IDS i ON i.EID = t1.EID
+                JOIN FILES f1 ON t1.FID = f1.FID
+                JOIN FILES f2 ON t2.FID = f2.FID
+                WHERE i.ORDINARY = 1 AND i.FUN = 0 AND i.READONLY = 0
+                AND f1.RO = 0 AND f2.RO = 0
+            """).fetchall()
+        else:
+            rows = conn.execute("""
+                SELECT DISTINCT f1.NAME AS SRC, f2.NAME AS DST
+                FROM TOKENS t1
+                JOIN TOKENS t2 ON t1.EID = t2.EID AND t1.FID != t2.FID
+                JOIN IDS i ON i.EID = t1.EID
+                JOIN FILES f1 ON t1.FID = f1.FID
+                JOIN FILES f2 ON t2.FID = f2.FID
+                WHERE i.ORDINARY = 1 AND i.FUN = 0 AND i.READONLY = 0
+            """).fetchall()
+        self._send_file_graph_svg(rows, "Data dependency graph")
+
+    def _send_file_graph_svg(self, rows, title):
+        """Generate and send a graphviz SVG for file dependency edges."""
+        if not rows:
+            html = f"""<!doctype html><html><body style="font-family:sans-serif;padding:2em">
+                <p>No dependencies found.</p></body></html>"""
+            body = html.encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        dot_lines = [
+            "digraph filedeps {",
+            '\trankdir=LR;',
+            '\tgraph [bgcolor=transparent];',
+            '\tnode [shape=box, fontname="Helvetica", fontsize=9];',
+            '\tedge [fontsize=8, color="#aaaaaa", arrowsize=0.8];',
+        ]
+        seen = set()
+        for row in rows:
+            src = os.path.basename(row["SRC"])
+            dst = os.path.basename(row["DST"])
+            if src not in seen:
+                seen.add(src)
+                if src.endswith('.h'):
+                    dot_lines.append(f'\t"{src}" [fillcolor="#3a6fa8", style=filled, fontcolor=white];')
+                else:
+                    dot_lines.append(f'\t"{src}" [fillcolor="#2d6b40", style=filled, fontcolor=white];')
+            if dst not in seen:
+                seen.add(dst)
+                if dst.endswith('.h'):
+                    dot_lines.append(f'\t"{dst}" [fillcolor="#3a6fa8", style=filled, fontcolor=white];')
+                else:
+                    dot_lines.append(f'\t"{dst}" [fillcolor="#2d6b40", style=filled, fontcolor=white];')
+            dot_lines.append(f'\t"{src}" -> "{dst}";')
+        dot_lines.append("}")
+        dot_source = "\n".join(dot_lines)
+
+        try:
+            result = subprocess.run(
+                ["dot", "-Tsvg"],
+                input=dot_source.encode("utf-8"),
+                capture_output=True,
+                timeout=15
+            )
+            if result.returncode != 0:
+                self.send_error_json(500, f"graphviz error: {result.stderr.decode()}")
+                return
+            svg = result.stdout.decode("utf-8")
+        except FileNotFoundError:
+            self.send_error_json(500, "graphviz not found")
+            return
+        except subprocess.TimeoutExpired:
+            self.send_error_json(500, "graphviz timed out")
+            return
+
+        html = f"""<!doctype html>
+    <html><head><meta charset="utf-8">
+    <style>
+    body {{ margin: 0; background: #1e1e1e; display: flex; flex-direction: column;
+        align-items: center; padding: 1em; }}
+    h2 {{ color: #ccc; font-family: Helvetica; font-size: 14px; margin-bottom: 1em; }}
+    svg {{ max-width: 100%; height: auto; }}
+    </style>
+    </head><body>
+    <h2>{title}</h2>
+    {svg}
+    </body></html>"""
+
+        body = html.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def main():
+    global _db_path
+
+    parser = argparse.ArgumentParser(
+        description="REST API server for querying a CScout SQLite database.")
+    parser.add_argument("db",
+                        help="Path to the CScout SQLite database file")
+    parser.add_argument("-p", "--port", type=int, default=8081,
+                        help="Port to listen on (default: 8081)")
+    parser.add_argument("--monitor-stdin", action="store_true",
+                        help="Monitor stdin and exit when it is closed (EOF)")
+    parser.add_argument("--pid-file", type=str, default=None,
+                        help="Path to write the server's PID file")
+    args = parser.parse_args()
+
+    _db_path = args.db
+
+    try:
+        conn = sqlite3.connect(_db_path)
+        conn.execute("SELECT COUNT(*) FROM IDS")
+        conn.close()
+    except Exception as e:
+        print(f"Error: cannot open database {_db_path}: {e}",
+              file=sys.stderr)
+        sys.exit(1)
+
+    if args.monitor_stdin:
+        def monitor_parent():
+            try:
+                sys.stdin.read()
+            except Exception:
+                pass
+            os._exit(0)
+        threading.Thread(target=monitor_parent, daemon=True).start()
+
+    if args.pid_file:
+        try:
+            with open(args.pid_file, "w") as f:
+                json.dump({"pid": os.getpid(), "port": args.port}, f)
+        except Exception as e:
+            print(f"Warning: could not write pid file: {e}", file=sys.stderr)
+
+    server = HTTPServer(("127.0.0.1", args.port), Handler)
+    print(f"CScout API ready at http://127.0.0.1:{args.port}",
+          file=sys.stderr)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        if args.pid_file:
+            try:
+                os.remove(args.pid_file)
+            except Exception:
+                pass
+
+
+if __name__ == "__main__":
+    main()

--- a/src/csapi.py
+++ b/src/csapi.py
@@ -46,6 +46,50 @@ class MissingParameterError(ValueError):
     """Exception raised when a required query parameter is missing or invalid."""
     pass
 
+SAVED_QUERIES_FILES = {
+    "writable": {"where": "f.RO = 0"},
+    "readonly": {"where": "f.RO = 1"},
+    "with_unused": {
+        "join": "JOIN TOKENS t ON t.FID = f.FID JOIN IDS i ON i.EID = t.EID",
+        "where": "i.UNUSED = 1 AND i.READONLY = 0",
+        "distinct": True
+    },
+    "no_statements": {
+        "join": "JOIN FILEMETRICS fm ON fm.FID = f.FID",
+        "where": "fm.PRECPP = 0 AND f.NAME LIKE '%.c' AND (fm.NSTMT = 0 OR fm.NSTMT IS NULL)"
+    },
+    "unprocessed": {
+        "join": "JOIN FILEMETRICS fm ON fm.FID = f.FID",
+        "where": "fm.PRECPP = 0 AND fm.NULINE > 0"
+    },
+    "with_strings": {
+        "join": "JOIN FILEMETRICS fm ON fm.FID = f.FID",
+        "where": "fm.PRECPP = 0 AND fm.NSTRING > 0"
+    },
+    "h_with_includes": {
+        "join": "JOIN FILEMETRICS fm ON fm.FID = f.FID",
+        "where": "f.NAME LIKE '%.h' AND fm.PRECPP = 1 AND fm.NINCFILE > 0"
+    }
+}
+
+SAVED_QUERIES_IDS = {
+    "readonly": {"where": "i.READONLY = 1 AND i.MACROARG = 0"},
+    "writable": {"where": "i.READONLY = 0 AND i.MACROARG = 0"},
+    "unused_project": {"where": "i.UNUSED = 1 AND i.LSCOPE = 1 AND i.READONLY = 0 AND i.MACROARG = 0"},
+    "unused_file": {"where": "i.UNUSED = 1 AND i.CSCOPE = 1 AND i.READONLY = 0 AND i.MACROARG = 0"},
+    "unused_macros": {"where": "i.UNUSED = 1 AND i.MACRO = 1 AND i.READONLY = 0 AND i.MACROARG = 0"},
+    "file_spanning": {"where": "i.READONLY = 0 AND i.EID IN (SELECT EID FROM TOKENS GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)"},
+    "static_vars": {"where": "i.READONLY = 0 AND i.ORDINARY = 1 AND i.LSCOPE = 1 AND i.NAME != 'main' AND i.EID NOT IN (SELECT EID FROM TOKENS GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)"},
+    "static_funs": {"where": "i.FUN = 1 AND i.READONLY = 0 AND i.ORDINARY = 1 AND i.LSCOPE = 1 AND i.NAME != 'main' AND i.EID NOT IN (SELECT EID FROM TOKENS GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)"},
+}
+
+SAVED_QUERIES_FUNCTIONS = {
+    "project_scoped": {"where": "f.FILESCOPED = 0 AND f.ISMACRO = 0"},
+    "file_scoped": {"where": "f.FILESCOPED = 1 AND f.ISMACRO = 0"},
+    "not_called": {"where": "f.FANIN = 0 AND f.ISMACRO = 0"},
+    "called_once": {"where": "f.FANIN = 1 AND f.ISMACRO = 0"},
+}
+
 
 def ensure_index(conn: sqlite3.Connection, table: str, columns: list) -> None:
     """Ensure that an index exists on the specified table and columns."""
@@ -258,39 +302,36 @@ class Handler(BaseHTTPRequestHandler):
     def handle_identifiers(self, conn, qs):
         """Handle /identifiers requests."""
         ensure_index(conn, "IDS", ["NAME"])
+        query = get_param(qs, "query")
+
         filters = [
-            ("unused", "UNUSED = ?", "bool"),
-            ("macro", "MACRO = ?", "bool"),
-            ("fun", "FUN = ?", "bool"),
-            ("readonly", "READONLY = ?", "bool"),
-            ("lscope", "LSCOPE = ?", "bool"),
-            ("cscope", "CSCOPE = ?", "bool"),
-            ("macroarg", "MACROARG = ?", "bool"),
-            ("ordinary", "ORDINARY = ?", "bool"),
-            ("name", "NAME LIKE ?", "like"),
-            ("name_ne", "NAME != ?", "str"),
+            ("name", "i.NAME LIKE ?", "like"),
+            ("name_ne", "i.NAME != ?", "str"),
         ]
         conditions, params = build_where_clause(qs, filters)
 
-        if get_bool_param(qs, "file_spanning"):
-            conditions.append(
-                "READONLY = 0"
-                " AND EID IN ("
-                "  SELECT EID FROM TOKENS"
-                "  GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)")
+        joins = []
+        distinct = False
 
-        if get_bool_param(qs, "not_file_spanning"):
-            conditions.append(
-                "EID NOT IN ("
-                "  SELECT EID FROM TOKENS"
-                "  GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)")
+        if query and query in SAVED_QUERIES_IDS:
+            sq = SAVED_QUERIES_IDS[query]
+            if "join" in sq:
+                joins.append(sq["join"])
+            if "where" in sq:
+                conditions.append(sq["where"])
+            if "distinct" in sq:
+                distinct = True
+
         limit, offset = get_paging_params(qs)
 
-        where = ("WHERE " + " AND ".join(conditions)
-                 if conditions else "")
+        join_str = " ".join(joins)
+        where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
         params += [limit, offset]
+        
+        distinct_str = "DISTINCT " if distinct else ""
+
         rows = conn.execute(
-            f"SELECT * FROM IDS {where} LIMIT ? OFFSET ?",
+            f"SELECT {distinct_str}i.* FROM IDS i {join_str} {where} LIMIT ? OFFSET ?",
             params).fetchall()
         self.send_json(rows_to_list(rows))
 
@@ -384,56 +425,34 @@ class Handler(BaseHTTPRequestHandler):
         has_strings=1    — files containing string literals (NSTRING>0)
         h_with_includes=1 — writable .h files with #include directives
         """
+        query = get_param(qs, "query")
+
         conditions = []
         params = []
         joins = []
-
-        if get_bool_param(qs, "writable"):
-            conditions.append("f.RO = 0")
-        if get_bool_param(qs, "ro"):
-            conditions.append("f.RO = 1")
+        distinct = False
 
         fre = get_param(qs, "fre")
         if fre:
             conditions.append("f.NAME LIKE ?")
             params.append(f"%{fre}%")
 
-        if get_bool_param(qs, "has_unused"):
-            joins.append(
-                "JOIN TOKENS t ON t.FID = f.FID "
-                "JOIN IDS i ON i.EID = t.EID")
-            conditions.append("i.UNUSED = 1 AND i.READONLY = 0")
-
-        needs_metrics = any(get_bool_param(qs, p) for p in
-                            ("no_statements", "unprocessed", "has_strings"))
-        if needs_metrics:
-            joins.append("JOIN FILEMETRICS fm ON fm.FID = f.FID")
-            conditions.append("fm.PRECPP = 0")
-
-        if get_bool_param(qs, "no_statements"):
-            conditions.append("f.NAME LIKE '%.c'")
-            conditions.append("(fm.NSTMT = 0 OR fm.NSTMT IS NULL)")
-
-        if get_bool_param(qs, "unprocessed"):
-            conditions.append("fm.NULINE > 0")
-
-        if get_bool_param(qs, "has_strings"):
-            conditions.append("fm.NSTRING > 0")
-
-        if get_bool_param(qs, "h_with_includes"):
-            # NINCFILE is a pre-cpp metric, handled via subquery
-            conditions.append("f.NAME LIKE '%.h'")
-            conditions.append(
-                "f.FID IN (SELECT fm2.FID FROM FILEMETRICS fm2 "
-                "WHERE fm2.PRECPP = 1 AND fm2.NINCFILE > 0)")
+        if query and query in SAVED_QUERIES_FILES:
+            sq = SAVED_QUERIES_FILES[query]
+            if "join" in sq:
+                joins.append(sq["join"])
+            if "where" in sq:
+                conditions.append(sq["where"])
+            if "distinct" in sq:
+                distinct = True
 
         join_str = " ".join(joins)
         where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
 
-        distinct = "DISTINCT" if get_bool_param(qs, "has_unused") else ""
+        distinct_str = "DISTINCT " if distinct else ""
 
         rows = conn.execute(
-            f"SELECT {distinct} f.FID, f.NAME, f.RO "
+            f"SELECT {distinct_str}f.FID, f.NAME, f.RO "
             f"FROM FILES f {join_str} {where} ORDER BY f.NAME",
             params).fetchall()
         self.send_json(rows_to_list(rows))
@@ -503,22 +522,32 @@ class Handler(BaseHTTPRequestHandler):
     def handle_functions(self, conn, qs):
         """Handle /functions requests."""
         ensure_index(conn, "LINEPOS", ["FID", "FOFFSET"])
+        query = get_param(qs, "query")
+
         filters = [
-            ("defined", "DEFINED = ?", "bool"),
-            ("filescoped", "FILESCOPED = ?", "bool"),
-            ("ismacro", "f.ISMACRO = ?", "bool"),
-            ("fanin", "f.FANIN = ?", "int"),
-            ("max_fanin", "f.FANIN <= ?", "int"),
+            ("name", "f.NAME LIKE ?", "like"),
         ]
         conditions, params = build_where_clause(qs, filters)
 
+        conditions.append("f.DEFINED = 1")
+        distinct = False
+
+        if query and query in SAVED_QUERIES_FUNCTIONS:
+            sq = SAVED_QUERIES_FUNCTIONS[query]
+            if "where" in sq:
+                conditions.append(sq["where"])
+            if "distinct" in sq:
+                distinct = True
+
         limit, offset = get_paging_params(qs)
 
-        where = ("WHERE " + " AND ".join(conditions)
-                 if conditions else "")
+        where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
         params += [limit, offset]
+        
+        distinct_str = "DISTINCT " if distinct else ""
+
         rows = conn.execute(
-            f"""SELECT f.ID, f.NAME, f.ISMACRO, f.DEFINED, f.DECLARED,
+            f"""SELECT {distinct_str}f.ID, f.NAME, f.ISMACRO, f.DEFINED, f.DECLARED,
                       f.FILESCOPED, f.FID, f.FOFFSET, f.FANIN,
                       fm.FANOUT, fm.CCYCL1, fi.NAME AS FILE, l.LNUM
                FROM FUNCTIONS f

--- a/src/csapi.py
+++ b/src/csapi.py
@@ -189,20 +189,6 @@ class Handler(BaseHTTPRequestHandler):
                 self.handle_attributes_files(conn, qs)
             elif path == "/files":
                 self.handle_files(conn, qs)
-            elif path == "/files/writable":
-                self.handle_files_writable(conn, qs)
-            elif path == "/files/readonly":
-                self.handle_files_readonly(conn, qs)
-            elif path == "/files/with-unused":
-                self.handle_files_with_unused(conn, qs)
-            elif path == "/files/no-statements":
-                self.handle_files_no_statements(conn, qs)
-            elif path == "/files/unprocessed":
-                self.handle_files_unprocessed(conn, qs)
-            elif path == "/files/with-strings":
-                self.handle_files_with_strings(conn, qs)
-            elif path == "/files/h-with-includes":
-                self.handle_files_h_with_includes(conn, qs)
             elif path == "/filegraph/include":
                 self.handle_filegraph_include(conn, qs)
             elif path == "/filegraph/compile":
@@ -225,10 +211,10 @@ class Handler(BaseHTTPRequestHandler):
                 self.handle_callees(conn, qs)
             elif path == "/projects":
                 self.handle_projects(conn, qs)
-            elif path == "/refactor/preview":
-                self.handle_refactor_preview(conn, qs)
-            elif path == "/refactor/apply":
-                self.handle_refactor_apply(conn, qs)
+            elif path == "/rename/preview":
+                self.handle_rename_preview(conn, qs)
+            elif path == "/rename/apply":
+                self.handle_rename_apply(conn, qs)
             elif path == "/identifier/detail":
                 self.handle_identifier_detail(conn, qs)
             elif path == "/filemetrics/aggregate":
@@ -282,6 +268,7 @@ class Handler(BaseHTTPRequestHandler):
             ("macroarg", "MACROARG = ?", "bool"),
             ("ordinary", "ORDINARY = ?", "bool"),
             ("name", "NAME LIKE ?", "like"),
+            ("name_ne", "NAME != ?", "str"),
         ]
         conditions, params = build_where_clause(qs, filters)
 
@@ -292,9 +279,11 @@ class Handler(BaseHTTPRequestHandler):
                 "  SELECT EID FROM TOKENS"
                 "  GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)")
 
-        if get_bool_param(qs, "should_be_static"):
-            conditions.append("READONLY = 0 AND ORDINARY = 1 AND LSCOPE = 1 AND NAME != 'main' AND EID NOT IN (SELECT EID FROM TOKENS GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)")
-
+        if get_bool_param(qs, "not_file_spanning"):
+            conditions.append(
+                "EID NOT IN ("
+                "  SELECT EID FROM TOKENS"
+                "  GROUP BY EID HAVING COUNT(DISTINCT FID) > 1)")
         limit, offset = get_paging_params(qs)
 
         where = ("WHERE " + " AND ".join(conditions)
@@ -383,9 +372,70 @@ class Handler(BaseHTTPRequestHandler):
         })
 
     def handle_files(self, conn, qs):
-        """Handle /files requests."""
+        """Handle /files requests with optional filters.
+
+        Parameters mirror the CScout web file query (xfilequery.html):
+        writable=1       — writable files only (RO=0)
+        ro=1             — read-only files only (RO=1)
+        fre=<regex>      — filter filenames matching SQL LIKE pattern
+        has_unused=1     — files containing unused writable identifiers
+        no_statements=1  — writable .c files with no statements (NSTMT=0)
+        unprocessed=1    — files with unprocessed lines (NULINE>0)
+        has_strings=1    — files containing string literals (NSTRING>0)
+        h_with_includes=1 — writable .h files with #include directives
+        """
+        conditions = []
+        params = []
+        joins = []
+
+        if get_bool_param(qs, "writable"):
+            conditions.append("f.RO = 0")
+        if get_bool_param(qs, "ro"):
+            conditions.append("f.RO = 1")
+
+        fre = get_param(qs, "fre")
+        if fre:
+            conditions.append("f.NAME LIKE ?")
+            params.append(f"%{fre}%")
+
+        if get_bool_param(qs, "has_unused"):
+            joins.append(
+                "JOIN TOKENS t ON t.FID = f.FID "
+                "JOIN IDS i ON i.EID = t.EID")
+            conditions.append("i.UNUSED = 1 AND i.READONLY = 0")
+
+        needs_metrics = any(get_bool_param(qs, p) for p in
+                            ("no_statements", "unprocessed", "has_strings"))
+        if needs_metrics:
+            joins.append("JOIN FILEMETRICS fm ON fm.FID = f.FID")
+            conditions.append("fm.PRECPP = 0")
+
+        if get_bool_param(qs, "no_statements"):
+            conditions.append("f.NAME LIKE '%.c'")
+            conditions.append("(fm.NSTMT = 0 OR fm.NSTMT IS NULL)")
+
+        if get_bool_param(qs, "unprocessed"):
+            conditions.append("fm.NULINE > 0")
+
+        if get_bool_param(qs, "has_strings"):
+            conditions.append("fm.NSTRING > 0")
+
+        if get_bool_param(qs, "h_with_includes"):
+            # NINCFILE is a pre-cpp metric, handled via subquery
+            conditions.append("f.NAME LIKE '%.h'")
+            conditions.append(
+                "f.FID IN (SELECT fm2.FID FROM FILEMETRICS fm2 "
+                "WHERE fm2.PRECPP = 1 AND fm2.NINCFILE > 0)")
+
+        join_str = " ".join(joins)
+        where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+
+        distinct = "DISTINCT" if get_bool_param(qs, "has_unused") else ""
+
         rows = conn.execute(
-            "SELECT * FROM FILES ORDER BY NAME").fetchall()
+            f"SELECT {distinct} f.FID, f.NAME, f.RO "
+            f"FROM FILES f {join_str} {where} ORDER BY f.NAME",
+            params).fetchall()
         self.send_json(rows_to_list(rows))
 
     def handle_filemetrics(self, conn, qs):
@@ -534,54 +584,38 @@ class Handler(BaseHTTPRequestHandler):
             self.send_json(dict(row))
 
     def handle_files_counts(self, conn, qs):
-        """Handle /files/counts — returns COUNT(*) per file sidebar category.
-
-        Replaces 8 separate API calls at panel open with one SQL query.
-        """
-        row = conn.execute("""
-            SELECT
-              COUNT(*) AS all_files,
-              SUM(CASE WHEN RO=1 THEN 1 ELSE 0 END) AS readonly,
-              SUM(CASE WHEN RO=0 THEN 1 ELSE 0 END) AS writable
-            FROM FILES
-        """).fetchone()
-        with_unused = conn.execute("""
-            SELECT COUNT(DISTINCT f.FID) FROM FILES f
-            JOIN TOKENS t ON t.FID = f.FID
-            JOIN IDS i ON i.EID = t.EID
-            WHERE f.RO=0 AND i.UNUSED=1 AND i.READONLY=0
-        """).fetchone()[0]
-        no_stmts = conn.execute("""
-            SELECT COUNT(*) FROM FILES f
-            JOIN FILEMETRICS fm ON fm.FID = f.FID
-            WHERE f.RO=0 AND f.NAME LIKE '%.c' AND fm.PRECPP=0
-            AND (fm.NSTMT=0 OR fm.NSTMT IS NULL)
-        """).fetchone()[0]
-        unprocessed = conn.execute("""
-            SELECT COUNT(*) FROM FILES f
-            JOIN FILEMETRICS fm ON fm.FID = f.FID
-            WHERE f.RO=0 AND fm.PRECPP=0 AND fm.NULINE > 0
-        """).fetchone()[0]
-        with_strings = conn.execute("""
-            SELECT COUNT(*) FROM FILES f
-            JOIN FILEMETRICS fm ON fm.FID = f.FID
-            WHERE f.RO=0 AND fm.PRECPP=0 AND fm.NSTRING > 0
-        """).fetchone()[0]
-        h_with_includes = conn.execute("""
-            SELECT COUNT(DISTINCT f.FID) FROM FILES f
-            JOIN INCLUDERS i ON i.INCLUDERID = f.FID
-            WHERE f.RO=0 AND f.NAME LIKE '%.h'
-        """).fetchone()[0]
-        self.send_json({
-            "all": row["all_files"],
-            "readonly": row["readonly"],
-            "writable": row["writable"],
-            "with_unused": with_unused,
-            "no_statements": no_stmts,
-            "unprocessed": unprocessed,
-            "with_strings": with_strings,
-            "h_with_includes": h_with_includes,
-        })
+        """Handle /files/counts — returns COUNT(*) per file sidebar category."""
+        rows = conn.execute("""
+            SELECT 'all' AS name, COUNT(*) AS value FROM FILES
+            UNION
+            SELECT 'readonly', COUNT(*) FROM FILES WHERE RO=1
+            UNION
+            SELECT 'writable', COUNT(*) FROM FILES WHERE RO=0
+            UNION
+            SELECT 'with_unused', COUNT(DISTINCT f.FID) FROM FILES f
+                JOIN TOKENS t ON t.FID = f.FID
+                JOIN IDS i ON i.EID = t.EID
+                WHERE f.RO=0 AND i.UNUSED=1 AND i.READONLY=0
+            UNION
+            SELECT 'no_statements', COUNT(*) FROM FILES f
+                JOIN FILEMETRICS fm ON fm.FID = f.FID
+                WHERE f.RO=0 AND f.NAME LIKE '%.c' AND fm.PRECPP=0
+                AND (fm.NSTMT=0 OR fm.NSTMT IS NULL)
+            UNION
+            SELECT 'unprocessed', COUNT(*) FROM FILES f
+                JOIN FILEMETRICS fm ON fm.FID = f.FID
+                WHERE f.RO=0 AND fm.PRECPP=0 AND fm.NULINE > 0
+            UNION
+            SELECT 'with_strings', COUNT(*) FROM FILES f
+                JOIN FILEMETRICS fm ON fm.FID = f.FID
+                WHERE f.RO=0 AND fm.PRECPP=0 AND fm.NSTRING > 0
+            UNION
+            SELECT 'h_with_includes', COUNT(DISTINCT f.FID) FROM FILES f
+                JOIN FILEMETRICS fm ON fm.FID = f.FID
+                WHERE f.RO=0 AND f.NAME LIKE '%.h'
+                AND fm.PRECPP=1 AND fm.NINCFILE > 0
+        """).fetchall()
+        self.send_json({row["name"]: row["value"] for row in rows})
 
     def handle_funmetrics(self, conn, qs):
         """Handle /funmetrics requests."""
@@ -635,8 +669,8 @@ class Handler(BaseHTTPRequestHandler):
             "SELECT * FROM PROJECTS").fetchall()
         self.send_json(rows_to_list(rows))
 
-    def handle_refactor_preview(self, conn, qs):
-        """Handle /refactor/preview requests."""
+    def handle_rename_preview(self, conn, qs):
+        """Handle /rename/preview requests."""
         ensure_index(conn, "TOKENS", ["EID"])
         ensure_index(conn, "LINEPOS", ["FID", "FOFFSET"])
         eid = get_required_int_param(qs, "eid")
@@ -998,8 +1032,8 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
-    def handle_refactor_apply(self, conn, qs):
-        """Handle /refactor/apply requests.
+    def handle_rename_apply(self, conn, qs):
+        """Handle /rename/apply requests.
 
         Performs byte-precise rename using token offsets from the DB.
         Modifies source files on disk. Only modifies writable files.
@@ -1056,88 +1090,6 @@ class Handler(BaseHTTPRequestHandler):
             "modified_files": modified_files,
             "total_replacements": len(tokens),
         })
-
-    def handle_files_writable(self, conn, qs):
-        """Writable files — RO=0."""
-        rows = conn.execute(
-            "SELECT * FROM FILES WHERE RO = 0 ORDER BY NAME"
-        ).fetchall()
-        self.send_json(rows_to_list(rows))
-
-    def handle_files_readonly(self, conn, qs):
-        """Read-only files — RO=1."""
-        rows = conn.execute(
-            "SELECT * FROM FILES WHERE RO = 1 ORDER BY NAME"
-        ).fetchall()
-        self.send_json(rows_to_list(rows))
-
-    def handle_files_with_unused(self, conn, qs):
-        """Writable files containing unused writable identifiers."""
-        rows = conn.execute(
-            """SELECT DISTINCT f.FID, f.NAME, f.RO
-            FROM FILES f
-            JOIN TOKENS t ON t.FID = f.FID
-            JOIN IDS i ON i.EID = t.EID
-            WHERE f.RO = 0
-                AND i.UNUSED = 1
-                AND i.READONLY = 0
-            ORDER BY f.NAME"""
-        ).fetchall()
-        self.send_json(rows_to_list(rows))
-
-    def handle_files_no_statements(self, conn, qs):
-        """Writable .c files without any statements (NSTMT=0, post-cpp)."""
-        rows = conn.execute(
-            """SELECT f.FID, f.NAME, f.RO
-            FROM FILES f
-            JOIN FILEMETRICS fm ON fm.FID = f.FID
-            WHERE f.RO = 0
-                AND f.NAME LIKE '%.c'
-                AND fm.PRECPP = 0
-                AND (fm.NSTMT = 0 OR fm.NSTMT IS NULL)
-            ORDER BY f.NAME"""
-        ).fetchall()
-        self.send_json(rows_to_list(rows))
-
-    def handle_files_unprocessed(self, conn, qs):
-        """Writable files containing unprocessed lines."""
-        rows = conn.execute(
-            """SELECT f.FID, f.NAME, f.RO
-            FROM FILES f
-            JOIN FILEMETRICS fm ON fm.FID = f.FID
-            WHERE f.RO = 0
-                AND fm.PRECPP = 0
-                AND fm.NULINE > 0
-            ORDER BY f.NAME"""
-        ).fetchall()
-        self.send_json(rows_to_list(rows))
-
-    def handle_files_with_strings(self, conn, qs):
-        """Writable files containing string literals."""
-        rows = conn.execute(
-            """SELECT f.FID, f.NAME, f.RO
-            FROM FILES f
-            JOIN FILEMETRICS fm ON fm.FID = f.FID
-            WHERE f.RO = 0
-                AND fm.PRECPP = 0
-                AND fm.NSTRING > 0
-            ORDER BY f.NAME"""
-        ).fetchall()
-        self.send_json(rows_to_list(rows))
-
-    def handle_files_h_with_includes(self, conn, qs):
-        """Writable .h files with #include directives."""
-        rows = conn.execute(
-            """SELECT f.FID, f.NAME, f.RO
-            FROM FILES f
-            JOIN FILEMETRICS fm ON fm.FID = f.FID
-            WHERE f.RO = 0
-                AND f.NAME LIKE '%.h'
-                AND fm.PRECPP = 1
-                AND fm.NINCFILE > 0
-            ORDER BY f.NAME"""
-        ).fetchall()
-        self.send_json(rows_to_list(rows))
 
     def handle_filegraph_include(self, conn, qs):
         """File include graph via graphviz."""

--- a/src/csapi.py
+++ b/src/csapi.py
@@ -796,126 +796,41 @@ class Handler(BaseHTTPRequestHandler):
         })
 
     def handle_attributes_identifiers(self, conn, qs):
-        """Return identifier attribute names and DB column ids.
-        Read from METADATA table if available, otherwise use built-in defaults.
-        """
-        try:
-            row = conn.execute(
-                "SELECT VALUE FROM METADATA WHERE KEY = 'IdentifierAttributes'"
-            ).fetchone()
-            if row:
-                names = row["VALUE"].split(',')
-                # Map names to DB column ids, in the same order as the METADATA value
-                ids = ["WRITABLE", "READONLY", "SUETAG", "SUMEMBER", "LABEL", "ORDINARY",
-                       "MACRO", "UNDEFMACRO", "MACROARG", "CSCOPE", "LSCOPE",
-                       "TYPEDEF", "ENUM", "YACC", "FUN", "UNUSED", "XFILE"]
-                result = [{"id": ids[i], "name": names[i]}
-                          for i in range(min(len(ids), len(names)))]
-                self.send_json(result)
-                return
-        except Exception:
-            pass
-        # Fallback to hardcoded list
-        self.send_json([
-            {"id": "WRITABLE",   "name": "Writable"},
-            {"id": "READONLY",   "name": "Read-only"},
-            {"id": "ORDINARY",   "name": "Ordinary identifier"},
-            {"id": "MACRO",      "name": "Macro"},
-            {"id": "FUNMACRO",   "name": "Function-like macro"},
-            {"id": "UNDEFMACRO", "name": "Undefined macro"},
-            {"id": "MACROARG",   "name": "Macro argument"},
-            {"id": "SUETAG",     "name": "Tag for struct/union/enum"},
-            {"id": "SUMEMBER",   "name": "Member of struct/union"},
-            {"id": "LABEL",      "name": "Label"},
-            {"id": "TYPEDEF",    "name": "Typedef"},
-            {"id": "ENUM",       "name": "Enumeration constant"},
-            {"id": "YACC",       "name": "Yacc identifier"},
-            {"id": "FUN",        "name": "Function"},
-            {"id": "CSCOPE",     "name": "File scope"},
-            {"id": "LSCOPE",     "name": "Project scope"},
-            {"id": "UNUSED",     "name": "Unused"},
-            {"id": "XFILE",      "name": "Crosses file boundary"},
-        ])
+        """Return identifier attribute names and DB column ids from METADATA."""
+        row = conn.execute(
+            "SELECT VALUE FROM METADATA WHERE KEY = 'IdentifierAttributes'"
+        ).fetchone()
+        if row is None:
+            self.send_error_json(404, "IdentifierAttributes not found in METADATA")
+            return
+        names = row["VALUE"].split(',')
+        ids = ["WRITABLE", "READONLY", "SUETAG", "SUMEMBER", "LABEL", "ORDINARY",
+               "MACRO", "UNDEFMACRO", "MACROARG", "CSCOPE", "LSCOPE",
+               "TYPEDEF", "ENUM", "YACC", "FUN", "UNUSED", "XFILE"]
+        self.send_json([{"id": ids[i], "name": names[i]}
+                        for i in range(min(len(ids), len(names)))])
 
     def handle_attributes_files(self, conn, qs):
-        """Return file metric names and DB column ids.
-        Read from METADATA table if available, otherwise use built-in defaults.
-        """
-        try:
-            row = conn.execute(
-                "SELECT VALUE FROM METADATA WHERE KEY = 'FileMetricFields'"
-            ).fetchone()
-            if row:
-                names = row["VALUE"].split(',')
-                ids = ["NCHAR","NCCOMMENT","NSPACE","NLCOMMENT","NBCOMMENT",
-                       "NLINE","MAXLINELEN","MAXSTMTLEN","MAXSTMTNEST",
-                       "MAXBRACENEST","MAXBRACKNEST","BRACENEST","BRACKNEST",
-                       "NULINE","NPPDIRECTIVE","NPPCOND","NPPFMACRO","NPPOMACRO",
-                       "NTOKEN","NSTMT","NOP","NUOP","NNCONST","NCLIT","NSTRING",
-                       "NPPCONCATOP","NPPSTRINGOP","NIF","NELSE","NSWITCH","NCASE",
-                       "NDEFAULT","NBREAK","NFOR","NWHILE","NDO","NCONTINUE",
-                       "NGOTO","NRETURN","NASM","NTYPEOF","NPID","NFID","NMID",
-                       "NID","NUPID","NUFID","NUMID","NUID","NLABEL",
-                       "NMACROEXPANDTOKEN"]
-                result = [{"id": ids[i], "name": names[i]}
-                          for i in range(min(len(ids), len(names)))]
-                self.send_json(result)
-                return
-        except Exception:
-            pass
-        self.send_json([
-            {"id": "NCHAR",             "name": "Number of characters"},
-            {"id": "NCCOMMENT",         "name": "Number of comment characters"},
-            {"id": "NSPACE",            "name": "Number of space characters"},
-            {"id": "NLCOMMENT",         "name": "Number of line comments"},
-            {"id": "NBCOMMENT",         "name": "Number of block comments"},
-            {"id": "NLINE",             "name": "Number of lines"},
-            {"id": "MAXLINELEN",        "name": "Maximum number of characters in a line"},
-            {"id": "MAXSTMTLEN",        "name": "Maximum number of tokens in a statement"},
-            {"id": "MAXSTMTNEST",       "name": "Maximum level of statement nesting"},
-            {"id": "MAXBRACENEST",      "name": "Maximum level of brace nesting"},
-            {"id": "MAXBRACKNEST",      "name": "Maximum level of bracket nesting"},
-            {"id": "BRACENEST",         "name": "Dangling brace nesting"},
-            {"id": "BRACKNEST",         "name": "Dangling bracket nesting"},
-            {"id": "NULINE",            "name": "Number of unprocessed lines"},
-            {"id": "NTOKEN",            "name": "Number of tokens"},
-            {"id": "NPPDIRECTIVE",      "name": "Number of C preprocessor directives"},
-            {"id": "NPPCOND",           "name": "Number of processed C preprocessor conditionals (ifdef, if, elif)"},
-            {"id": "NPPFMACRO",         "name": "Number of defined C preprocessor function-like macros"},
-            {"id": "NPPOMACRO",         "name": "Number of defined C preprocessor object-like macros"},
-            {"id": "NPPCONCATOP",       "name": "Number of token concatenation operators (##)"},
-            {"id": "NPPSTRINGOP",       "name": "Number of token stringification operators (#)"},
-            {"id": "NSTMT",             "name": "Number of statements or declarations"},
-            {"id": "NOP",               "name": "Number of operators"},
-            {"id": "NUOP",              "name": "Number of unique operators"},
-            {"id": "NNCONST",           "name": "Number of numeric constants"},
-            {"id": "NCLIT",             "name": "Number of character literals"},
-            {"id": "NSTRING",           "name": "Number of character strings"},
-            {"id": "NIF",               "name": "Number of if statements"},
-            {"id": "NELSE",             "name": "Number of else clauses"},
-            {"id": "NSWITCH",           "name": "Number of switch statements"},
-            {"id": "NCASE",             "name": "Number of case labels"},
-            {"id": "NDEFAULT",          "name": "Number of default labels"},
-            {"id": "NBREAK",            "name": "Number of break statements"},
-            {"id": "NFOR",              "name": "Number of for statements"},
-            {"id": "NWHILE",            "name": "Number of while statements"},
-            {"id": "NDO",               "name": "Number of do statements"},
-            {"id": "NCONTINUE",         "name": "Number of continue statements"},
-            {"id": "NGOTO",             "name": "Number of goto statements"},
-            {"id": "NRETURN",           "name": "Number of return statements"},
-            {"id": "NASM",              "name": "Number of assembly statements"},
-            {"id": "NTYPEOF",           "name": "Number of typeof operators"},
-            {"id": "NPID",              "name": "Number of project-scope identifiers"},
-            {"id": "NFID",              "name": "Number of file-scope (static) identifiers"},
-            {"id": "NMID",              "name": "Number of macro identifiers"},
-            {"id": "NID",               "name": "Total number of object and object-like identifiers"},
-            {"id": "NUPID",             "name": "Number of unique project-scope identifiers"},
-            {"id": "NUFID",             "name": "Number of unique file-scope (static) identifiers"},
-            {"id": "NUMID",             "name": "Number of unique macro identifiers"},
-            {"id": "NUID",              "name": "Number of unique object and object-like identifiers"},
-            {"id": "NLABEL",            "name": "Number of goto labels"},
-            {"id": "NMACROEXPANDTOKEN", "name": "Tokens added by macro expansion"},
-        ])
+        """Return file metric names and DB column ids from METADATA."""
+        row = conn.execute(
+            "SELECT VALUE FROM METADATA WHERE KEY = 'FileMetricFields'"
+        ).fetchone()
+        if row is None:
+            self.send_error_json(404, "FileMetricFields not found in METADATA")
+            return
+        names = row["VALUE"].split(',')
+        ids = ["NCHAR","NCCOMMENT","NSPACE","NLCOMMENT","NBCOMMENT",
+               "NLINE","MAXLINELEN","MAXSTMTLEN","MAXSTMTNEST",
+               "MAXBRACENEST","MAXBRACKNEST","BRACENEST","BRACKNEST",
+               "NULINE","NPPDIRECTIVE","NPPCOND","NPPFMACRO","NPPOMACRO",
+               "NTOKEN","NSTMT","NOP","NUOP","NNCONST","NCLIT","NSTRING",
+               "NPPCONCATOP","NPPSTRINGOP","NIF","NELSE","NSWITCH","NCASE",
+               "NDEFAULT","NBREAK","NFOR","NWHILE","NDO","NCONTINUE",
+               "NGOTO","NRETURN","NASM","NTYPEOF","NPID","NFID","NMID",
+               "NID","NUPID","NUFID","NUMID","NUID","NLABEL",
+               "NMACROEXPANDTOKEN"]
+        self.send_json([{"id": ids[i], "name": names[i]}
+                        for i in range(min(len(ids), len(names)))])
 
     def handle_filemetrics_aggregate(self, conn, qs):
         """Handle /filemetrics/aggregate requests.

--- a/src/csapi.py
+++ b/src/csapi.py
@@ -804,9 +804,10 @@ class Handler(BaseHTTPRequestHandler):
             self.send_error_json(404, "IdentifierAttributes not found in METADATA")
             return
         names = row["VALUE"].split(',')
-        ids = ["WRITABLE", "READONLY", "SUETAG", "SUMEMBER", "LABEL", "ORDINARY",
-               "MACRO", "UNDEFMACRO", "MACROARG", "CSCOPE", "LSCOPE",
-               "TYPEDEF", "ENUM", "YACC", "FUN", "UNUSED", "XFILE"]
+        ids = ["READONLY", "SUETAG", "SUMEMBER", "LABEL", "ORDINARY",
+               "MACRO", "UNDEFMACRO", "UNDEFEDMACRO", "REDEFEDSAMEMACRO",
+               "REDEFEDDIFFMACRO", "MACROARG", "CSCOPE", "LSCOPE",
+               "TYPEDEF", "ENUM", "YACC", "FUN"]
         self.send_json([{"id": ids[i], "name": names[i]}
                         for i in range(min(len(ids), len(names)))])
 

--- a/src/dest-install.sh
+++ b/src/dest-install.sh
@@ -103,6 +103,7 @@ install $TMPFILE "$PREFIX/bin/cscc"
 
 install cscut.sh "$PREFIX/bin/cscut"
 install cssplit.py "$PREFIX/bin/cssplit"
+install csapi.py "$PREFIX/bin/csapi"
 # Python script requiring include path replacement
 sed "s|INSTALL_INCLUDE|$INCLUDE_DIR|g" cscoco.py >$TMPFILE
 install $TMPFILE "$PREFIX/bin/cscoco"

--- a/src/test_csapi.py
+++ b/src/test_csapi.py
@@ -222,8 +222,8 @@ class TestCsapi(unittest.TestCase):
         data = self.get_json("/projects")
         self.assertTrue(any(p["NAME"] == "TestProject" for p in data))
 
-    def test_refactor_preview(self):
-        data = self.get_json(f"/refactor/preview?eid={self.eid_global_var}&newname=renamed_var")
+    def test_rename_preview(self):
+        data = self.get_json(f"/rename/preview?eid={self.eid_global_var}&newname=renamed_var")
         self.assertEqual(data["eid"], self.eid_global_var)
         self.assertEqual(data["old_name"], "sample_global_var")
         self.assertEqual(data["new_name"], "renamed_var")

--- a/src/test_csapi.py
+++ b/src/test_csapi.py
@@ -234,7 +234,7 @@ class TestCsapi(unittest.TestCase):
     def test_attributes_identifiers(self):
         data = self.get_json("/attributes/identifiers")
         self.assertGreater(len(data), 0)
-        self.assertTrue(any(a["id"] == "XFILE" for a in data))
+        self.assertTrue(any(a["id"] == "READONLY" for a in data))
         self.assertTrue(any(a["id"] == "FUN" for a in data))
 
     def test_attributes_files(self):

--- a/src/test_csapi.py
+++ b/src/test_csapi.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+#
+# (C) Copyright 2026 Diomidis Spinellis
+# (C) Copyright 2026 Ujjwal Aggarwal
+#
+# This file is part of CScout.
+#
+# CScout is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# CScout is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CScout.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import json
+import os
+import sqlite3
+import subprocess
+import tempfile
+import textwrap
+import threading
+import unittest
+import urllib.request
+import urllib.error
+from http.server import HTTPServer
+
+import csapi
+
+
+class TestCsapi(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.db_fd, cls.db_path = tempfile.mkstemp()
+        os.close(cls.db_fd)
+        csapi._db_path = cls.db_path
+
+        base_dir = os.path.dirname(os.path.abspath(__file__))
+        cscout_bin = os.environ.get("CSCOUT", os.path.join(base_dir, "build", "cscout"))
+
+        cls.c_file_path = os.path.join(base_dir, "test", "c", "test_csapi_sample.c")
+        with open(cls.c_file_path, "w") as f:
+            f.write(textwrap.dedent("""\
+                int sample_global_var = 1;
+                void sample_global_func(void) {
+                }
+                #define SAMPLE_MACRO 42
+                static void sample_static_func(void) {
+                    sample_global_func();
+                }
+            """))
+
+        cls.ws_spec_path = os.path.join(base_dir, "test_ws.ws")
+        with open(cls.ws_spec_path, "w") as f:
+            f.write(textwrap.dedent("""\
+                workspace TestWS {
+                    ipath "../include/stdc"
+                    directory test/c {
+                        project TestProject {
+                            file test_csapi_sample.c
+                        }
+                    }
+                }
+            """))
+
+        cls.project_cs_path = os.path.join(base_dir, "test_project.cs")
+        cswc_res = subprocess.run(
+            ["perl", "cswc.pl", "-d", "../example/.cscout", "test_ws.ws"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=base_dir
+        )
+        if cswc_res.returncode != 0:
+            raise RuntimeError(f"cswc.pl failed: {cswc_res.stderr}")
+
+        with open(cls.project_cs_path, "w") as f:
+            f.write(cswc_res.stdout)
+
+        cscout_res = subprocess.run(
+            [cscout_bin, "-s", "sqlite", "test_project.cs"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=base_dir
+        )
+        if cscout_res.returncode != 0:
+            raise RuntimeError(f"cscout failed: {cscout_res.stderr}")
+
+        conn = sqlite3.connect(cls.db_path)
+        conn.executescript(cscout_res.stdout)
+
+        cursor = conn.cursor()
+        cursor.execute("SELECT EID FROM IDS WHERE NAME = 'sample_global_var'")
+        cls.eid_global_var = cursor.fetchone()[0]
+        cursor.execute("SELECT EID FROM IDS WHERE NAME = 'sample_global_func'")
+        cls.eid_global_func = cursor.fetchone()[0]
+        cursor.execute("SELECT EID FROM IDS WHERE NAME = 'SAMPLE_MACRO'")
+        cls.eid_sample_macro = cursor.fetchone()[0]
+        cursor.execute("SELECT EID FROM IDS WHERE NAME = 'sample_static_func'")
+        cls.eid_static_func = cursor.fetchone()[0]
+
+        cursor.execute("SELECT FID FROM FILES WHERE NAME LIKE '%test_csapi_sample.c'")
+        cls.fid_sample = cursor.fetchone()[0]
+
+        cursor.execute("SELECT ID FROM FUNCTIONS WHERE NAME = 'sample_global_func'")
+        cls.fnid_global_func = cursor.fetchone()[0]
+        cursor.execute("SELECT ID FROM FUNCTIONS WHERE NAME = 'sample_static_func'")
+        cls.fnid_static_func = cursor.fetchone()[0]
+
+        conn.close()
+
+        cls.server = HTTPServer(("127.0.0.1", 0), csapi.Handler)
+        cls.port = cls.server.server_address[1]
+        cls.server_thread = threading.Thread(target=cls.server.serve_forever)
+        cls.server_thread.daemon = True
+        cls.server_thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        # Hit /quit first because the server checks an internal flag on that
+        # endpoint; server.shutdown() alone does not trigger it.
+        try:
+            req = urllib.request.Request(f"http://127.0.0.1:{cls.port}/quit")
+            with urllib.request.urlopen(req) as response:
+                pass
+        except Exception:
+            pass
+
+        try:
+            cls.server.shutdown()
+            cls.server_thread.join(timeout=2)
+        except Exception:
+            pass
+
+        for path in (cls.db_path, cls.c_file_path, cls.ws_spec_path, cls.project_cs_path):
+            try:
+                os.remove(path)
+            except Exception:
+                pass
+
+    def get_url(self, path):
+        return f"http://127.0.0.1:{self.port}{path}"
+
+    def get_json(self, path):
+        req = urllib.request.Request(self.get_url(path))
+        with urllib.request.urlopen(req) as response:
+            self.assertEqual(response.status, 200)
+            return json.loads(response.read().decode('utf-8'))
+
+    def test_status(self):
+        data = self.get_json("/status")
+        self.assertEqual(data["status"], "ok")
+        self.assertTrue(data["indexes_ready"])
+
+    def test_identifiers(self):
+        data = self.get_json("/identifiers")
+        self.assertGreater(len(data), 0)
+
+        data_unused = self.get_json("/identifiers?unused=1")
+        self.assertTrue(any(r["NAME"] == "sample_global_var" for r in data_unused))
+
+        data_search = self.get_json("/identifiers?name=sample_global_func")
+        self.assertEqual(len(data_search), 1)
+        self.assertEqual(data_search[0]["NAME"], "sample_global_func")
+
+        data_paged = self.get_json("/identifiers?limit=1&offset=1")
+        self.assertEqual(len(data_paged), 1)
+
+    def test_identifier(self):
+        data = self.get_json(f"/identifier?eid={self.eid_global_var}")
+        self.assertEqual(data["identifier"]["NAME"], "sample_global_var")
+        self.assertEqual(len(data["locations"]), 1)
+        self.assertEqual(data["locations"][0]["LNUM"], 1)
+
+        with self.assertRaises(urllib.error.HTTPError) as cm:
+            self.get_json("/identifier?eid=999999999")
+        self.assertEqual(cm.exception.code, 404)
+
+        with self.assertRaises(urllib.error.HTTPError) as cm:
+            self.get_json("/identifier")
+        self.assertEqual(cm.exception.code, 400)
+
+    def test_files(self):
+        data = self.get_json("/files")
+        self.assertTrue(any(f["NAME"].endswith("test_csapi_sample.c") for f in data))
+
+    def test_filemetrics(self):
+        data = self.get_json(f"/filemetrics?fid={self.fid_sample}")
+        self.assertEqual(len(data), 2)
+        self.assertIn("NSTMT", data[0])
+
+    def test_functions(self):
+        data = self.get_json("/functions")
+        self.assertTrue(any(f["NAME"] == "sample_global_func" for f in data))
+        self.assertTrue(any(f["NAME"] == "sample_static_func" for f in data))
+
+        data_scoped = self.get_json("/functions?filescoped=1")
+        self.assertTrue(any(f["NAME"] == "sample_static_func" for f in data_scoped))
+
+    def test_funmetrics(self):
+        data = self.get_json(f"/funmetrics?fnid={self.fnid_static_func}")
+        self.assertEqual(len(data), 2)
+        post_cpp = next(r for r in data if r["PRECPP"] == 0)
+        self.assertEqual(post_cpp["FANOUT"], 1)
+
+    def test_callers(self):
+        data = self.get_json(f"/callers?fnid={self.fnid_global_func}")
+        self.assertTrue(any(f["NAME"] == "sample_static_func" for f in data))
+
+    def test_callees(self):
+        data = self.get_json(f"/callees?fnid={self.fnid_static_func}")
+        self.assertTrue(any(f["NAME"] == "sample_global_func" for f in data))
+
+    def test_projects(self):
+        data = self.get_json("/projects")
+        self.assertTrue(any(p["NAME"] == "TestProject" for p in data))
+
+    def test_refactor_preview(self):
+        data = self.get_json(f"/refactor/preview?eid={self.eid_global_var}&newname=renamed_var")
+        self.assertEqual(data["eid"], self.eid_global_var)
+        self.assertEqual(data["old_name"], "sample_global_var")
+        self.assertEqual(data["new_name"], "renamed_var")
+        self.assertEqual(data["total_replacements"], 1)
+        self.assertEqual(len(data["locations"]), 1)
+
+
+    def test_attributes_identifiers(self):
+        data = self.get_json("/attributes/identifiers")
+        self.assertGreater(len(data), 0)
+        self.assertTrue(any(a["id"] == "XFILE" for a in data))
+        self.assertTrue(any(a["id"] == "FUN" for a in data))
+
+    def test_attributes_files(self):
+        data = self.get_json("/attributes/files")
+        self.assertGreater(len(data), 0)
+        self.assertTrue(any(a["id"] == "NLINE" for a in data))
+        self.assertTrue(any(a["id"] == "NSTMT" for a in data))
+
+
+class TestCsapiHelpers(unittest.TestCase):
+    def test_rows_to_list(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        cursor.execute("CREATE TABLE t (a INT, b TEXT)")
+        cursor.execute("INSERT INTO t VALUES (1, 'hello')")
+        row = cursor.execute("SELECT * FROM t").fetchone()
+        res = csapi.rows_to_list([row])
+        self.assertEqual(res, [{"a": 1, "b": "hello"}])
+        conn.close()
+
+    def test_get_param(self):
+        qs = {"a": ["first", "second"], "b": []}
+        self.assertEqual(csapi.get_param(qs, "a"), "first")
+        self.assertEqual(csapi.get_param(qs, "b"), None)
+        self.assertEqual(csapi.get_param(qs, "c", "default_val"), "default_val")
+
+    def test_get_bool_param(self):
+        qs = {
+            "a": ["1"],
+            "b": ["true"],
+            "c": ["yes"],
+            "d": ["0"],
+            "e": ["false"],
+            "f": ["other"]
+        }
+        self.assertTrue(csapi.get_bool_param(qs, "a"))
+        self.assertTrue(csapi.get_bool_param(qs, "b"))
+        self.assertTrue(csapi.get_bool_param(qs, "c"))
+        self.assertFalse(csapi.get_bool_param(qs, "d"))
+        self.assertFalse(csapi.get_bool_param(qs, "e"))
+        self.assertFalse(csapi.get_bool_param(qs, "f"))
+        self.assertIsNone(csapi.get_bool_param(qs, "missing"))
+
+    def test_get_int_param(self):
+        qs = {"a": ["42"], "b": ["not_an_int"]}
+        self.assertEqual(csapi.get_int_param(qs, "a", 10), 42)
+        self.assertEqual(csapi.get_int_param(qs, "b", 10), 10)
+        self.assertEqual(csapi.get_int_param(qs, "missing", 10), 10)
+
+    def test_get_required_param(self):
+        qs = {"a": ["hello"]}
+        self.assertEqual(csapi.get_required_param(qs, "a"), "hello")
+        with self.assertRaises(csapi.MissingParameterError):
+            csapi.get_required_param(qs, "missing")
+
+    def test_get_required_int_param(self):
+        qs = {"a": ["42"], "b": ["not_an_int"]}
+        self.assertEqual(csapi.get_required_int_param(qs, "a"), 42)
+        with self.assertRaises(csapi.MissingParameterError):
+            csapi.get_required_int_param(qs, "b")
+        with self.assertRaises(csapi.MissingParameterError):
+            csapi.get_required_int_param(qs, "missing")
+
+    def test_get_paging_params(self):
+        qs = {"limit": ["10"], "offset": ["20"]}
+        limit, offset = csapi.get_paging_params(qs)
+        self.assertEqual(limit, 10)
+        self.assertEqual(offset, 20)
+
+        limit, offset = csapi.get_paging_params({})
+        self.assertEqual(limit, 1000)
+        self.assertEqual(offset, 0)
+
+    def test_build_where_clause(self):
+        qs = {
+            "unused": ["1"],
+            "name": ["func"],
+            "missing": ["123"]
+        }
+        filters = [
+            ("unused", "UNUSED = ?", "bool"),
+            ("macro", "MACRO = ?", "bool"),
+            ("name", "NAME LIKE ?", "like"),
+        ]
+        conditions, params = csapi.build_where_clause(qs, filters)
+        self.assertEqual(conditions, ["UNUSED = ?", "NAME LIKE ?"])
+        self.assertEqual(params, [1, "%func%"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This replaces #135, which accumulated unrelated commits through repeated merges with `gsoc-2026`. This PR contains the same
csapi feature reduced to a single clean commit on top of the current `gsoc-2026`, with all review feedback from #135 already incorporated (dynamic indexing, end-to-end tests, OpenAPI documentation, man page).

## Summary

Adds `csapi`, a lightweight REST API server that reads a CScout SQLite database and exposes the analysis results as JSON over a local HTTP server.

After running:

    cscout -s sqlite project.cs | sqlite3 project.db

the server is started with:

    csapi project.db

and is available at `http://localhost:8081`